### PR TITLE
Fixed two cost handling bugs.

### DIFF
--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -1159,26 +1159,33 @@ namespace ProceduralParts
         [KSPField]
         public float costPerkL = 245f;
 
+        [KSPField(isPersistant=true, guiActiveEditor=true, guiName="cost")]
+        public float moduleCost = 0f;
+
         public float GetModuleCost()
         {
-            float cost = 0f;
-            if((object)shape != null)
-                cost = shape.costMultiplier * shape.Volume * costPerkL;
-            if (part.Modules.Contains("TankContentSwitcher"))
+            if (HighLogic.LoadedScene == GameScenes.EDITOR || HighLogic.LoadedScene == GameScenes.SPH)
             {
-                TankContentSwitcher switcher = (TankContentSwitcher)part.Modules["TankContentSwitcher"];
-                cost *= switcher.GetCurrentCostMult();
-            }
-            if (!part.Modules.Contains("ModuleFuelTanks") && (object)PartResourceLibrary.Instance != null)
-            {
-                foreach (PartResource r in part.Resources)
+                float cost = 0f;
+                if ((object)shape != null)
+                    cost = shape.costMultiplier * shape.Volume * costPerkL;
+                if (part.Modules.Contains("TankContentSwitcher"))
                 {
-                    PartResourceDefinition d = PartResourceLibrary.Instance.GetDefinition(r.resourceName);
-                    if((object)d != null)
-                        cost += (float)(r.maxAmount * d.unitCost);
+                    TankContentSwitcher switcher = (TankContentSwitcher)part.Modules["TankContentSwitcher"];
+                    cost *= switcher.GetCurrentCostMult();
                 }
+                if (!part.Modules.Contains("ModuleFuelTanks") && (object)PartResourceLibrary.Instance != null)
+                {
+                    foreach (PartResource r in part.Resources)
+                    {
+                        PartResourceDefinition d = PartResourceLibrary.Instance.GetDefinition(r.resourceName);
+                        if ((object)d != null)
+                            cost += (float)(r.maxAmount * d.unitCost);
+                    }
+                }
+                moduleCost = cost;
             }
-            return cost;
+            return moduleCost;
         }
         #endregion
 

--- a/Source/TankContentSwitcher.cs
+++ b/Source/TankContentSwitcher.cs
@@ -141,7 +141,14 @@ namespace ProceduralParts
         public string tankType;
 
         private TankTypeOption selectedTankType;
-        public float GetCurrentCostMult() { return selectedTankType.costMultiplier; }
+        
+        public float GetCurrentCostMult()
+        {
+            if (null != selectedTankType)
+                return selectedTankType.costMultiplier;
+            else
+                return 0; // tank type has not been initialized yet
+        }
         private List<TankTypeOption> tankTypeOptions;
 
         // This should be private, but there's a bug in KSP.


### PR DESCRIPTION
- Receiving the current cost multiplier from the TankContentSwitcher leads to an exception when the TankContentSwitcher has not been initialized yet.
- When recovering a vessel, the price of the procedural part would be handled as 0. Easy way to fix this: calculate costs only in editor and save it to persistence.
