### PR TITLE
decoupler glitch #63

### DIFF
--- a/Source/ProceduralShapePill.cs
+++ b/Source/ProceduralShapePill.cs
@@ -50,7 +50,7 @@ namespace ProceduralParts
             else
             {
                 diameterEdit.maxValue = PPart.diameterMax;
-                diameterEdit.minValue = useEndDiameter ? 0 : PPart.diameterMin;
+                diameterEdit.minValue = PPart.diameterMin;
                 diameterEdit.incrementLarge = PPart.diameterLargeStep;
                 diameterEdit.incrementSmall = PPart.diameterSmallStep;
             }


### PR DESCRIPTION
fixed a glitching decoupler, that appeared in career mode.
users could set the diameter under the minimum value which leads to the shape glitching out.
