### PR TITLE
Incomplete fix of editor mass discrepancies

### DIFF
--- a/Source/TankContentSwitcher.cs
+++ b/Source/TankContentSwitcher.cs
@@ -21,7 +21,7 @@ namespace ProceduralParts
     /// The class also accepts the message ChangeVolume(float volume) if attached to a dynamic resizing part
     /// such as ProceeduralTanks.
     /// </summary>
-    public class TankContentSwitcher : PartModule
+    public class TankContentSwitcher : PartModule, IPartMassModifier
     {
         #region Callbacks
         public override void OnAwake()
@@ -453,10 +453,17 @@ namespace ProceduralParts
         }
 
         #endregion
+        
+        #region Mass
+		public float GetModuleMass(float defaultMass)
+		{
+			return part.mass - defaultMass;
+		}
+		#endregion
     }
 
 
-    public class TankContentSwitcherRealFuels : PartModule
+    public class TankContentSwitcherRealFuels : PartModule, IPartMassModifier
     {
         public override void OnAwake()
         {
@@ -650,5 +657,12 @@ namespace ProceduralParts
                 massDisplay = "Dry: " + MathUtils.FormatMass(part.mass) + " / Wet: " + MathUtils.FormatMass(totalMass);
             }
         }
+        
+        #region Mass
+		public float GetModuleMass(float defaultMass)
+		{
+			return part.mass - defaultMass;
+		}
+		#endregion
     }
 }


### PR DESCRIPTION
The editor shows incorrect mass information for tanks in the new "i" toolbar button, like what is shown here: https://imgur.com/ahra20t.  This tries to fix the masses being out of whack, but suffers from an update delay problem where the toolbar shows the last-edited state of the tank (maybe some kind of race condition on the editor update call?)  Hopefully will be of some use.

Note the RealFuels section is totally untested.
