### PR TITLE
Limit SRB Changes to RO

### DIFF
--- a/ModuleManager/RealismOverhaul_TechLimits.cfg
+++ b/ModuleManager/RealismOverhaul_TechLimits.cfg
@@ -127,7 +127,7 @@
 		}
 	}
 }
-@PART[proceduralTankSRBRFHigh]:Final
+@PART[proceduralTankSRBRFHigh]:Final:NEEDS[RealismOverhaul]
 {
 	@MODULE[ProceduralShape*]
 	{
@@ -184,7 +184,7 @@
 		}
 	}
 }
-@PART[proceduralSRBRealFuels]:Final
+@PART[proceduralSRBRealFuels]:Final:NEEDS[RealismOverhaul]
 {
 	@MODULE[ProceduralPart]
 	{


### PR DESCRIPTION
Adds a couple of NEEDS[RealismOverhaul] to ensure these only apply to RO, was messing up my SETI+PP+RF install. See http://forum.kerbalspaceprogram.com/threads/106130-0-90-SETI-BalanceMod-Scope-Economy-Tech-Integration-v0-8-5-Mar-20?p=1802057&viewfull=1#post1802057 the problems it was causing.
