### PR TITLE
CFG fixes for 1.0 (and ablator)

### DIFF
--- a/Parts/Structural/Structural.cfg
+++ b/Parts/Structural/Structural.cfg
@@ -50,60 +50,64 @@ PART
 		
 		// Use same limits as liquid fuel tanks 
 		TECHLIMIT {
-			// FL-200 - 1.25 x 1.1105 m = 1.363 kL
-			name = start
+			// FL-T100 - 1.25 x 0.78125 m = 0.959 kL
+			name = basicRocketry
 			diameterMin = 1.0
 			diameterMax = 1.5
-			lengthMin = 1.0
+			lengthMin = 0.5
+			lengthMax = 1.0
+			volumeMin = 0.7
+			volumeMax = 1.0
+		}
+		TECHLIMIT {
+			// FL-T200 - 1.25 x 1.1105 m = 1.363 kL
+			name = generalRocketry
+			diameterMin = 1.0
+			diameterMax = 1.5
+			lengthMin = 0.5
 			lengthMax = 1.5
 			volumeMin = 1.0
 			volumeMax = 1.5
 		}
 		TECHLIMIT {
 			// FL-T400 - 1.25 x 1.87819 m = 2.305 kL
-			// FL-T100 - 1.25 x 0.78125 m = 0.959 kL
-			name = basicRocketry
+			name = advRocketry
 			lengthMin = 0.5
 			lengthMax = 2.0
-			volumeMin = 0.75
+			volumeMin = 0.7
 			volumeMax = 2.5
 		}
 		TECHLIMIT {
 			// FL-T800 - 1.25 x 3.75 m = 4.602 kL
-			name = advRocketry
-			lengthMax = 4.0
-			volumeMax = 5.0
-		}
-		TECHLIMIT {
-			// X200-16 - 2.5 x 1.875 m = 9.204 kL
-			name = heavyRocketry
-			diameterMax = 3.0
-			volumeMax = 10.0
-		}
-		TECHLIMIT {
 			// X200-32 - 2.5 x 3.75 m = 18.408 kL
-			name = heavierRocketry
-			volumeMax = 20.0
+			name = fuelSystems
+			lengthMax = 4.0
+			diameterMax = 3.0
+			volumeMax = 20
 		}
 		TECHLIMIT {
 			// Jumbo-64 - 2.5 x 7.5 m = 36.816 kL
-			name = veryHeavyRocketry
-			lengthMax = 8
-			volumeMax = 40.0
+			name = advFuelSystems
+			lengthMax = 8.0
+			volumeMax = 37.0
 		}
-		
 		TECHLIMIT {
-			// Not in main sequence. Depends indirectly off basicRocketry only
-			// X200-8 - 2.5 x 0.9375 m = 4.602 kL
-			name = advConstruction
-			diameterMax = 3.0
-			volumeMax = 5.0
+			// Kerbodyne S3-7200 - 3.75 x 4.0
+			name = largeVolumeContainment
+			diameterMax = 5.0
+			volumeMax = 45.0
 		}
-		
+		TECHLIMIT {
+			// Kerbodyne S3-14400 - 3.75 x 7.5 = 82.614kl
+			name = highPerformanceFuelSystems
+			volumeMax = 85.0
+			diameterMax = 5.0
+		}
+
 		TECHLIMIT {
 			// Not in main sequence. Depends indirectly off basicRocketry
 			// Oscar-B - 0.625 x 0.3485474 m = 0.107 kL
-			name = precisionEngineering
+			name = propulsionSystems
 			diameterMin = 0.125
 			lengthMin = 0.125
 			volumeMin = 0.0625

--- a/Parts/Tanks/1TankLiquid.cfg
+++ b/Parts/Tanks/1TankLiquid.cfg
@@ -49,19 +49,28 @@ PART
 		name = ProceduralPart
 		
 		TECHLIMIT {
-			// FL-200 - 1.25 x 1.1105 m = 1.363 kL
-			name = start
+			// FL-T100 - 1.25 x 0.78125 m = 0.959 kL
+			name = basicRocketry
 			diameterMin = 1.0
 			diameterMax = 1.5
-			lengthMin = 1.0
+			lengthMin = 0.5
+			lengthMax = 1.0
+			volumeMin = 0.7
+			volumeMax = 1.0
+		}
+		TECHLIMIT {
+			// FL-T200 - 1.25 x 1.1105 m = 1.363 kL
+			name = generalRocketry
+			diameterMin = 1.0
+			diameterMax = 1.5
+			lengthMin = 0.5
 			lengthMax = 1.5
 			volumeMin = 1.0
 			volumeMax = 1.5
 		}
 		TECHLIMIT {
 			// FL-T400 - 1.25 x 1.87819 m = 2.305 kL
-			// FL-T100 - 1.25 x 0.78125 m = 0.959 kL
-			name = basicRocketry
+			name = advRocketry
 			lengthMin = 0.5
 			lengthMax = 2.0
 			volumeMin = 0.7
@@ -69,41 +78,35 @@ PART
 		}
 		TECHLIMIT {
 			// FL-T800 - 1.25 x 3.75 m = 4.602 kL
-			name = advRocketry
-			lengthMax = 4.0
-			volumeMax = 5.0
-		}
-		TECHLIMIT {
 			// X200-32 - 2.5 x 3.75 m = 18.408 kL
-			name = heavyRocketry
+			name = fuelSystems
+			lengthMax = 4.0
 			diameterMax = 3.0
-			volumeMax = 20.0
+			volumeMax = 20
 		}
 		TECHLIMIT {
 			// Jumbo-64 - 2.5 x 7.5 m = 36.816 kL
-			name = heavierRocketry
-			lengthMax = 8
-			volumeMax = 40.0
+			name = advFuelSystems
+			lengthMax = 8.0
+			volumeMax = 37.0
+		}
+		TECHLIMIT {
+			// Kerbodyne S3-7200 - 3.75 x 4.0
+			name = largeVolumeContainment
+			diameterMax = 5.0
+			volumeMax = 45.0
 		}
 		TECHLIMIT {
 			// Kerbodyne S3-14400 - 3.75 x 7.5 = 82.614kl
-			name = veryHeavyRocketry
+			name = highPerformanceFuelSystems
 			volumeMax = 85.0
 			diameterMax = 5.0
 		}
 
 		TECHLIMIT {
-			// Not in main sequence. Depends indirectly off basicRocketry only
-			// X200-8 - 2.5 x 0.9375 m = 4.602 kL
-			name = advConstruction
-			diameterMax = 3.0
-			volumeMax = 5.0
-		}
-		
-		TECHLIMIT {
 			// Not in main sequence. Depends indirectly off basicRocketry
 			// Oscar-B - 0.625 x 0.3485474 m = 0.107 kL
-			name = precisionEngineering
+			name = propulsionSystems
 			diameterMin = 0.125
 			lengthMin = 0.125
 			volumeMin = 0.0625

--- a/Parts/Tanks/2TankRCS.cfg
+++ b/Parts/Tanks/2TankRCS.cfg
@@ -21,7 +21,7 @@ PART
 
 	// --- editor parameters ---
 	cost = 0 // 4000
-	TechRequired = fuelSystems
+	TechRequired = advFuelSystems
 	entryCost = 4000
 	category = Propulsion
 	subcategory = 0
@@ -50,34 +50,14 @@ PART
 		textureSet = Stockalike
 		
 		TECHLIMIT {
-			// FL-R25 - 1.25 x 0.5706054 m = 0.700238177 kL
-			name = fuelSystems
-			diameterMin = 1.0
-			diameterMax = 1.75
-			lengthMin = 0.25
-			lengthMax = 0.75
-			volumeMin = 0.5
-			volumeMax = 2.0
-		}
-		TECHLIMIT {
 			// FL-R1 - 2.5 x 1 m = 4.91 kL
-			name = heavyRocketry
+			name = advFuelSystems
 			diameterMin = 1.75
 			diameterMax = 3.0
 			lengthMin = 0.75
 			lengthMax = 2.0
 			volumeMin = 2.0
 			volumeMax = 6.0
-		}
-		TECHLIMIT {
-			// FL-R10 - 0.625 x 0.375 m = 0.1150 kL
-			name = precisionEngineering
-			diameterMin = 0.125
-			diameterMax = 1.0
-			lengthMin = 0.125
-			lengthMax = 0.5
-			volumeMin = 0.0625
-			volumeMax = 0.5
 		}
 		
 		TECHLIMIT {

--- a/Parts/Tanks/4SRB.cfg
+++ b/Parts/Tanks/4SRB.cfg
@@ -87,6 +87,16 @@ PART
 		
 		// Lengths for the stock tanks are approximate as one needs to account for the bell.
 		TECHLIMIT {
+			// RT-5 - 1.25 x 1.2 m = 1.45 kL
+			name = start
+			diameterMin = 1.0
+			diameterMax = 1.75
+			lengthMin = 1.0
+			lengthMax = 2.0
+			volumeMin = 1.0
+			volumeMax = 2.0
+		}
+		TECHLIMIT {
 			// RT-10 - 1.25 x 2.4 m = 2.95 kL
 			name = start
 			diameterMin = 1.0

--- a/Parts/ZOtherMods/DREHeatshield.cfg
+++ b/Parts/ZOtherMods/DREHeatshield.cfg
@@ -41,7 +41,8 @@ PART
 	crashTolerance = 9
 	breakingForce = 630
 	breakingTorque = 630
-	maxTemp = 1800
+	maxTemp = 3400
+	thermalMassModifier = 0.001
 
 	MODULE
 	{

--- a/Parts/ZOtherMods/DREHeatshield.cfg
+++ b/Parts/ZOtherMods/DREHeatshield.cfg
@@ -1,4 +1,4 @@
-PART:NEEDS[DeadlyReentry]
+PART
 {
 	// --- general parameters ---
 	name = proceduralHeatshield
@@ -23,7 +23,7 @@ PART:NEEDS[DeadlyReentry]
 	cost = 0 // 4200
 	TechRequired = survivability
 	entryCost = 4200
-	category = Structural
+	category = Aero
 	subcategory = 0
 	title = Procedural Heatshield
 	manufacturer = Kerbchem Industries
@@ -56,16 +56,16 @@ PART:NEEDS[DeadlyReentry]
 
 		
 		TECHLIMIT {
-			name = start
+			name = survivability
 			diameterMin = 1.0
 			diameterMax = 1.5
 		}
 		TECHLIMIT {
-			name = heavyRocketry
+			name = landing
 			diameterMax = 3.0
 		}
 		TECHLIMIT {
-			name = heavierRocketry
+			name = advLanding
 			diameterMax = 5	
 		}
 		TECHLIMIT {
@@ -107,8 +107,8 @@ PART:NEEDS[DeadlyReentry]
 			isStructural = true
 			RESOURCE 
 			{
-				name = AblativeShielding
-				unitsPerKL = 1210.8
+				name = Ablator
+				unitsPerKL = 1636.2
 			}
 		}
 
@@ -123,26 +123,12 @@ PART:NEEDS[DeadlyReentry]
 	}
 	MODULE
 	{
-		name = ModuleHeatShield
-		direction = 0, -1, 0 // bottom of pod
-		reflective = 0.05 // 5% of heat is ignored at correct angle
-		ablative = AblativeShielding
-		loss
-		{ // loss is based on the shockwave temperature (also based on density)
-			// These will vary based on the procedural heatshield
-		}
-		dissipation
-		{ 
-			// These will vary based on the procedural heatshield
-		}
-	}
-	MODULE
-	{
-		name = ProceduralHeatshield
-		
-		// If you don't like the default settings for these, give a factor to change the loss and dissipation by
-		
-		//lossTweak = 1.0
-		//dissipationTweak = 1.0
+		name = ModuleAblator
+		ablativeResource = Ablator
+		lossExp = -9000
+		lossConst = 20
+		pyrolysisLossFactor = 10000
+		reentryConductivity = 0.01
+		ablationTempThresh = 500
 	}
 }

--- a/Parts/ZOtherMods/RFSRB.cfg
+++ b/Parts/ZOtherMods/RFSRB.cfg
@@ -95,6 +95,16 @@ PART:NEEDS[RealFuels&!ModularFuelTanks]
 		
 		// Lengths for the stock tanks are approximate as one needs to account for the bell.
 		TECHLIMIT {
+			// RT-5 - 1.25 x 1.2 m = 1.45 kL
+			name = start
+			diameterMin = 1.0
+			diameterMax = 1.75
+			lengthMin = 1.0
+			lengthMax = 2.0
+			volumeMin = 1.0
+			volumeMax = 2.0
+		}
+		TECHLIMIT {
 			// RT-10 - 1.25 x 2.4 m = 2.95 kL
 			name = start
 			diameterMin = 1.0

--- a/Parts/ZOtherMods/RFTank.cfg
+++ b/Parts/ZOtherMods/RFTank.cfg
@@ -57,19 +57,28 @@ PART:NEEDS[RealFuels&!ModularFuelTanks]
 		costPerkL = 0.00957
 		
 		TECHLIMIT {
-			// FL-200 - 1.25 x 1.1105 m = 1.363 kL
-			name = start
+			// FL-T100 - 1.25 x 0.78125 m = 0.959 kL
+			name = basicRocketry
 			diameterMin = 1.0
 			diameterMax = 1.5
-			lengthMin = 1.0
+			lengthMin = 0.5
+			lengthMax = 1.0
+			volumeMin = 0.7
+			volumeMax = 1.0
+		}
+		TECHLIMIT {
+			// FL-T200 - 1.25 x 1.1105 m = 1.363 kL
+			name = generalRocketry
+			diameterMin = 1.0
+			diameterMax = 1.5
+			lengthMin = 0.5
 			lengthMax = 1.5
 			volumeMin = 1.0
 			volumeMax = 1.5
 		}
 		TECHLIMIT {
 			// FL-T400 - 1.25 x 1.87819 m = 2.305 kL
-			// FL-T100 - 1.25 x 0.78125 m = 0.959 kL
-			name = basicRocketry
+			name = advRocketry
 			lengthMin = 0.5
 			lengthMax = 2.0
 			volumeMin = 0.7
@@ -77,40 +86,35 @@ PART:NEEDS[RealFuels&!ModularFuelTanks]
 		}
 		TECHLIMIT {
 			// FL-T800 - 1.25 x 3.75 m = 4.602 kL
-			name = advRocketry
-			lengthMax = 4.0
-			volumeMax = 5.0
-		}
-		TECHLIMIT {
-			// X200-16 - 2.5 x 1.875 m = 9.204 kL
-			name = heavyRocketry
-			diameterMax = 3.0
-			volumeMax = 10.0
-		}
-		TECHLIMIT {
 			// X200-32 - 2.5 x 3.75 m = 18.408 kL
-			name = heavierRocketry
-			volumeMax = 20.0
+			name = fuelSystems
+			lengthMax = 4.0
+			diameterMax = 3.0
+			volumeMax = 20
 		}
 		TECHLIMIT {
 			// Jumbo-64 - 2.5 x 7.5 m = 36.816 kL
-			name = veryHeavyRocketry
-			lengthMax = 8
-			volumeMax = 40.0
+			name = advFuelSystems
+			lengthMax = 8.0
+			volumeMax = 37.0
 		}
-		
 		TECHLIMIT {
-			// Not in main sequence. Depends indirectly off basicRocketry only
-			// X200-8 - 2.5 x 0.9375 m = 4.602 kL
-			name = advConstruction
-			diameterMax = 3.0
-			volumeMax = 5.0
+			// Kerbodyne S3-7200 - 3.75 x 4.0
+			name = largeVolumeContainment
+			diameterMax = 5.0
+			volumeMax = 45.0
 		}
-		
+		TECHLIMIT {
+			// Kerbodyne S3-14400 - 3.75 x 7.5 = 82.614kl
+			name = highPerformanceFuelSystems
+			volumeMax = 85.0
+			diameterMax = 5.0
+		}
+
 		TECHLIMIT {
 			// Not in main sequence. Depends indirectly off basicRocketry
 			// Oscar-B - 0.625 x 0.3485474 m = 0.107 kL
-			name = precisionEngineering
+			name = propulsionSystems
 			diameterMin = 0.125
 			lengthMin = 0.125
 			volumeMin = 0.0625


### PR DESCRIPTION
This is a set of CFG fixes to realign the PP balance with the balance of the stock tanks in 1.0.

There are two notable issues:
First, SRBs don't retain their bell data. srbConfigsSerialized gets cleared whenever the SRB is cloned.
Second, the heatshield never ablates - there's probably something a little wrong with the config there.
