### PR TITLE
Attachment fix

### DIFF
--- a/Parts/Electrical/Battery.cfg
+++ b/Parts/Electrical/Battery.cfg
@@ -39,7 +39,7 @@ PART
 	minimum_drag = 0.2
 	angularDrag = 1
 	crashTolerance = 8
-	maxTemp = 3200
+	maxTemp = 2000
 
 	MODULE
 	{

--- a/Parts/Structural/NoseCone.cfg
+++ b/Parts/Structural/NoseCone.cfg
@@ -37,7 +37,7 @@ PART
 	minimum_drag = 0.1
 	angularDrag = 0.25
 	crashTolerance = 15
-	maxTemp = 3400
+	maxTemp = 2400
 
 	MODULE
 	{

--- a/Parts/Structural/StackDecoupler.cfg
+++ b/Parts/Structural/StackDecoupler.cfg
@@ -41,7 +41,7 @@ PART
 	minimum_drag = 0.2
 	angularDrag = 2
 	crashTolerance = 7 
-	maxTemp = 3400
+	maxTemp = 2000
 	fuelCrossFeed = False
 
 	stageOffset = 1

--- a/Parts/Structural/Structural.cfg
+++ b/Parts/Structural/Structural.cfg
@@ -41,7 +41,7 @@ PART
 	crashTolerance = 7
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2900
+	maxTemp = 2000
 
 	MODULE
 	{

--- a/Parts/Tanks/1TankLiquid.cfg
+++ b/Parts/Tanks/1TankLiquid.cfg
@@ -41,7 +41,7 @@ PART
 	crashTolerance = 7
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2900
+	maxTemp = 2000
 
 
 	MODULE

--- a/Parts/Tanks/2TankRCS.cfg
+++ b/Parts/Tanks/2TankRCS.cfg
@@ -42,7 +42,7 @@ PART
 	crashTolerance = 7
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 2900
+	maxTemp = 2000
 
 	MODULE
 	{

--- a/Parts/Tanks/3TankXenon.cfg
+++ b/Parts/Tanks/3TankXenon.cfg
@@ -42,7 +42,7 @@ PART
 	crashTolerance = 7
 	breakingForce = 50
 	breakingTorque = 50
-	maxTemp = 2900
+	maxTemp = 2000
 
 	MODULE
 	{

--- a/Parts/Tanks/ConeLiquid.cfg
+++ b/Parts/Tanks/ConeLiquid.cfg
@@ -40,7 +40,7 @@ PART
 	crashTolerance = 7
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2900
+	maxTemp = 2000
 
 
 	MODULE

--- a/Parts/Tanks/TankOre.cfg
+++ b/Parts/Tanks/TankOre.cfg
@@ -1,0 +1,138 @@
+PART
+{
+	// --- general parameters ---
+	name = proceduralTankOre
+	module = Part
+	author = Ckfinite, AncientGammoner, NathanKell, Swamp Ig, OtherBarry
+
+	// --- asset parameters ---
+	MODEL
+	{
+		model = ProceduralParts/Parts/cylinderTank
+		scale = 1,1,1
+	}
+	scale = 1
+	rescaleFactor = 1
+
+	// --- node definitions ---
+	node_stack_top=0,0.5,0,0,1,0,1
+	node_stack_bottom=0,-0.5,0,0,-1,0,1
+	node_attach=0,0,0.5,0,0,-1,1
+
+	// --- editor parameters ---
+	cost = 0 // 4000
+	TechRequired = advScienceTech
+	entryCost = 4000
+	category = Utility
+	subcategory = 0
+	title = Procedural Ore Tank
+	manufacturer = Kerbchem Industries
+	description = Made from viscoelastic nanopolymers (which were discovered by accident... growing in the back of the office mini-fridge) this fuel tank can be stretched to accommodate ore in a range of sizes and shapes. Hardens to a rigid structure before launch!
+
+	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	attachRules = 1,1,1,1,0
+
+	// --- standard part parameters ---
+	mass = 0
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 1
+	crashTolerance = 12
+	breakingForce = 500
+	breakingTorque = 500
+	maxTemp = 3200
+
+
+	MODULE
+	{
+		name = ProceduralPart
+		
+		TECHLIMIT {
+			name = advScienceTech
+			diameterMin = 0.1
+			diameterMax = 1.5
+			lengthMin = 0.1
+			lengthMax = 1.75
+			volumeMin = 0.1
+			volumeMax = 2.5
+		}
+
+		TECHLIMIT {
+			name = experimentalScience
+			diameterMax = 3.0
+			volumeMax = 15.0
+			lengthMax = 5.0
+		}
+
+		TECHLIMIT {
+			// Make everything unlimited for metaMaterials
+			name = metaMaterials
+			diameterMin = 0.01
+			diameterMax = Infinity
+			lengthMin = 0.01
+			lengthMax = Infinity
+			volumeMin = 0.01
+			volumeMax = Infinity
+		}
+		costPerkL=424
+	}
+	MODULE
+	{
+		name = ProceduralShapeCylinder
+		displayName = Cylinder
+		techRequired = start
+		
+		length = 1.0
+		diameter = 1.25
+	}
+	MODULE 
+	{
+		name = ProceduralShapeCone
+		displayName = Cone
+		techRequired = generalConstruction
+		
+		length = 1.0
+		topDiameter = 0.625
+		bottomDiameter = 1.25
+	}
+	MODULE 
+	{
+		name = ProceduralShapePill
+		displayName = Fillet Cylinder
+		techRequired = advConstruction
+		
+		length = 1.0
+		diameter = 1.25
+		fillet = 0.25
+	}
+	MODULE 
+	{
+		name = ProceduralShapeBezierCone
+		displayName = Smooth Cone
+		techRequired = advConstruction
+		
+		length = 1.0
+		topDiameter = 0.625
+		bottomDiameter = 1.25
+	}
+	MODULE
+	{
+		name = TankContentSwitcher
+		useVolume = true
+		
+
+		TANK_TYPE_OPTION 
+		{
+			name = Ore
+			// This is the dry mass of the tank per kL of volume.
+			dryDensity = 0.17
+			RESOURCE 
+			{
+				name = Ore
+				unitsPerKL = 139.664
+			}
+		}
+
+	}
+}

--- a/Parts/Tanks/TankOre.cfg
+++ b/Parts/Tanks/TankOre.cfg
@@ -41,7 +41,7 @@ PART
 	crashTolerance = 12
 	breakingForce = 500
 	breakingTorque = 500
-	maxTemp = 3200
+	maxTemp = 2000
 
 
 	MODULE

--- a/Parts/ZOtherMods/RFTank.cfg
+++ b/Parts/ZOtherMods/RFTank.cfg
@@ -48,7 +48,7 @@ PART:NEEDS[RealFuels&!ModularFuelTanks]
 	crashTolerance = 10
 	breakingForce = 200
 	breakingTorque = 200
-	maxTemp = 2900
+	maxTemp = 2000
 
 
 	MODULE

--- a/Parts/ZOtherMods/TankExtraplanetary.cfg
+++ b/Parts/ZOtherMods/TankExtraplanetary.cfg
@@ -41,7 +41,7 @@ PART:NEEDS[Launchpad]
 	crashTolerance = 12
 	breakingForce = 500
 	breakingTorque = 500
-	maxTemp = 3200
+	maxTemp = 2000
 
 
 	MODULE

--- a/Parts/ZOtherMods/TankKethane.cfg
+++ b/Parts/ZOtherMods/TankKethane.cfg
@@ -41,7 +41,7 @@ PART:NEEDS[Kethane]
 	crashTolerance = 12
 	breakingForce = 500
 	breakingTorque = 500
-	maxTemp = 3200
+	maxTemp = 2000
 
 
 	MODULE

--- a/Parts/ZOtherMods/TankLifeSupport.cfg
+++ b/Parts/ZOtherMods/TankLifeSupport.cfg
@@ -41,7 +41,7 @@ PART:NEEDS[TacLifeSupport]
 	crashTolerance = 12
 	breakingForce = 500
 	breakingTorque = 500
-	maxTemp = 3200
+	maxTemp = 2000
 
 
 	MODULE

--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -147,12 +147,8 @@ namespace ProceduralParts
             }
         }
 
-        public IEnumerator<YieldInstruction> UpdateDragCube()
+        public void UpdateDragCube()
         {
-            while (!FlightGlobals.ready || this.part.packed || !this.vessel.loaded)
-            {
-                yield return new WaitForFixedUpdate();
-            }
             DragCube dragCube = DragCubeSystem.Instance.RenderProceduralDragCube(base.part);
 
             base.part.DragCubes.ClearCubes();
@@ -174,7 +170,8 @@ namespace ProceduralParts
                     if (wasForce)
                     {
                         ChangeVolume(volumeName, Volume);
-                        StartCoroutine(UpdateDragCube());
+                        //if (FlightGlobals.ready && !this.part.packed && this.vessel.loaded)
+                            UpdateDragCube();
                         if (HighLogic.LoadedSceneIsEditor)
                             GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
                     }

--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -3,6 +3,7 @@ using KSPAPIExtensions;
 using UnityEngine;
 using KSPAPIExtensions.PartMessage;
 using System.Reflection;
+using System.Collections.Generic;
 
 namespace ProceduralParts
 {
@@ -146,8 +147,12 @@ namespace ProceduralParts
             }
         }
 
-        public void UpdateDragCube()
+        public IEnumerator<YieldInstruction> UpdateDragCube()
         {
+            while (!FlightGlobals.ready || this.part.packed || !this.vessel.loaded)
+            {
+                yield return new WaitForFixedUpdate();
+            }
             DragCube dragCube = DragCubeSystem.Instance.RenderProceduralDragCube(base.part);
 
             base.part.DragCubes.ClearCubes();
@@ -169,7 +174,7 @@ namespace ProceduralParts
                     if (wasForce)
                     {
                         ChangeVolume(volumeName, Volume);
-                        UpdateDragCube();
+                        StartCoroutine(UpdateDragCube());
                         if (HighLogic.LoadedSceneIsEditor)
                             GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
                     }

--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -147,8 +147,12 @@ namespace ProceduralParts
             }
         }
 
-        public void UpdateDragCube()
+        public IEnumerator<YieldInstruction> UpdateDragCube()
         {
+            while (!FlightGlobals.ready || this.part.packed || !this.vessel.loaded)
+            {
+                yield return new WaitForFixedUpdate();
+            }
             DragCube dragCube = DragCubeSystem.Instance.RenderProceduralDragCube(base.part);
 
             base.part.DragCubes.ClearCubes();
@@ -170,8 +174,7 @@ namespace ProceduralParts
                     if (wasForce)
                     {
                         ChangeVolume(volumeName, Volume);
-                        //if (FlightGlobals.ready && !this.part.packed && this.vessel.loaded)
-                            UpdateDragCube();
+                        StartCoroutine(UpdateDragCube());
                         if (HighLogic.LoadedSceneIsEditor)
                             GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
                     }

--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -92,10 +92,6 @@ namespace ProceduralParts
                 if (HighLogic.LoadedSceneIsEditor)
                     symmetryClone = true;
 
-                while (toAttach.Count() > 0) {
-                    toAttach.Dequeue().Invoke();
-                }
-
                 Fields["costDisplay"].guiActiveEditor = displayCost;
             }
             catch (Exception ex)
@@ -901,11 +897,6 @@ namespace ProceduralParts
         [PartMessageListener(typeof(PartChildAttached), scenes: GameSceneFilter.AnyEditor)]
         public void PartChildAttached(Part child)
         {
-            if (shape == null) //OnUpdate hasn't fired yet
-            {
-                toAttach.Enqueue(() => PartChildAttached(child));
-                return;
-            }
             AttachNode node = child.findAttachNodeByPart(part);
             if (node == null)
             {
@@ -956,11 +947,6 @@ namespace ProceduralParts
         [PartMessageListener(typeof(PartParentChanged), scenes: GameSceneFilter.AnyEditor)]
         public void PartParentChanged(Part newParent)
         {
-            if (shape == null) //OnUpdate hasn't fired yet
-            {
-                toAttach.Enqueue(() => PartParentChanged(newParent));
-                return;
-            }
             if (parentAttachment != null)
             {
                 RemovePartAttachment(parentAttachment);
@@ -996,17 +982,13 @@ namespace ProceduralParts
             shape.ForceNextUpdate();
         }
 
-        private Queue<Action> toAttach = new Queue<Action>();
         private PartAttachment AddPartAttachment(Vector3 position, TransformFollower.Transformable target, bool normalized = false)
         {
             if ((object)target == null)
                 Debug.Log("AddPartAttachment: null target!");
-
             TransformFollower follower = TransformFollower.CreateFollower(partModel, position, target);
-
             if((object)follower == null)
                 Debug.Log("AddPartAttachment: null follower!");
-
             object data = shape.AddAttachment(follower, normalized);
 
             return new PartAttachment(follower, data);

--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -92,10 +92,6 @@ namespace ProceduralParts
                 if (HighLogic.LoadedSceneIsEditor)
                     symmetryClone = true;
 
-                if (HighLogic.LoadedSceneIsEditor)
-                    while (toAttach.Count() > 0) {
-                        toAttach.Dequeue().Invoke();
-                    }
 
                 Fields["costDisplay"].guiActiveEditor = displayCost;
             }
@@ -104,6 +100,15 @@ namespace ProceduralParts
                 Debug.LogException(ex);
                 isEnabled = enabled = false;
             }
+        }
+
+        public void LateUpdate()
+        {
+            if (HighLogic.LoadedSceneIsEditor)
+                while (toAttach.Count() > 0)
+                {
+                    toAttach.Dequeue().Invoke();
+                }
         }
 
         public void OnUpdateEditor()

--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -92,6 +92,10 @@ namespace ProceduralParts
                 if (HighLogic.LoadedSceneIsEditor)
                     symmetryClone = true;
 
+                while (toAttach.Count() > 0) {
+                    toAttach.Dequeue().Invoke();
+                }
+
                 Fields["costDisplay"].guiActiveEditor = displayCost;
             }
             catch (Exception ex)
@@ -897,6 +901,11 @@ namespace ProceduralParts
         [PartMessageListener(typeof(PartChildAttached), scenes: GameSceneFilter.AnyEditor)]
         public void PartChildAttached(Part child)
         {
+            if (shape == null) //OnUpdate hasn't fired yet
+            {
+                toAttach.Enqueue(() => PartChildAttached(child));
+                return;
+            }
             AttachNode node = child.findAttachNodeByPart(part);
             if (node == null)
             {
@@ -947,6 +956,11 @@ namespace ProceduralParts
         [PartMessageListener(typeof(PartParentChanged), scenes: GameSceneFilter.AnyEditor)]
         public void PartParentChanged(Part newParent)
         {
+            if (shape == null) //OnUpdate hasn't fired yet
+            {
+                toAttach.Enqueue(() => PartParentChanged(newParent));
+                return;
+            }
             if (parentAttachment != null)
             {
                 RemovePartAttachment(parentAttachment);
@@ -982,13 +996,17 @@ namespace ProceduralParts
             shape.ForceNextUpdate();
         }
 
+        private Queue<Action> toAttach = new Queue<Action>();
         private PartAttachment AddPartAttachment(Vector3 position, TransformFollower.Transformable target, bool normalized = false)
         {
             if ((object)target == null)
                 Debug.Log("AddPartAttachment: null target!");
+
             TransformFollower follower = TransformFollower.CreateFollower(partModel, position, target);
+
             if((object)follower == null)
                 Debug.Log("AddPartAttachment: null follower!");
+
             object data = shape.AddAttachment(follower, normalized);
 
             return new PartAttachment(follower, data);

--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -92,9 +92,10 @@ namespace ProceduralParts
                 if (HighLogic.LoadedSceneIsEditor)
                     symmetryClone = true;
 
-                while (toAttach.Count() > 0) {
-                    toAttach.Dequeue().Invoke();
-                }
+                if (HighLogic.LoadedSceneIsEditor)
+                    while (toAttach.Count() > 0) {
+                        toAttach.Dequeue().Invoke();
+                    }
 
                 Fields["costDisplay"].guiActiveEditor = displayCost;
             }

--- a/Source/ProceduralSRB.cs
+++ b/Source/ProceduralSRB.cs
@@ -57,7 +57,7 @@ namespace ProceduralParts
             try
             {
                 InitializeBells();
-                UpdateMaxThrust();  
+                UpdateMaxThrust();
             }
             catch (Exception ex)
             {
@@ -497,6 +497,9 @@ namespace ProceduralParts
                 GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
         }
 
+        [KSPField]
+        public double fuelRate = 0.0;
+
         private void UpdateThrustDependentCalcs()
         {
             PartResource solidFuel = part.Resources["SolidFuel"];
@@ -513,7 +516,8 @@ namespace ProceduralParts
             {
                 float burnTime0 = burnTimeME = (float)(atmosphereCurve.Evaluate(0) * solidFuelMassG / thrust);
                 float burnTime1 = (float)(atmosphereCurve.Evaluate(1) * solidFuelMassG / thrust);
-                burnTime = string.Format("{0:F1}s ({1:F1}s Vac)", burnTime1, burnTime0);                
+                burnTime = string.Format("{0:F1}s ({1:F1}s Vac)", burnTime1, burnTime0);
+                fuelRate = solidFuelMassG / burnTime0;
             }
             else
             {
@@ -529,6 +533,7 @@ namespace ProceduralParts
 
                 thrustME = thrust0.ToStringSI(unit: "N", exponent: 3) + " Vac / " + thrust1.ToStringSI(unit: "N", exponent: 3) + " ASL";
                 srbISP = string.Format("{1:F0}s Vac / {0:F0}s ASL", atmosphereCurve.Evaluate(1), atmosphereCurve.Evaluate(0));
+                fuelRate = solidFuelMassG / burnTimeME;
             }
 
             // This equation is much easier. From StretchySRBs
@@ -550,6 +555,8 @@ namespace ProceduralParts
         {
             Engine.heatProduction = heatProduction;
             Engine.maxThrust = thrust;
+            part.GetComponent<ModuleEngines>().maxFuelFlow = (float)(0.1*fuelRate);
+
 
             selectedBell.model.transform.localScale = new Vector3(bellScale, bellScale, bellScale);
 

--- a/Source/ProceduralSRB.cs
+++ b/Source/ProceduralSRB.cs
@@ -156,8 +156,8 @@ namespace ProceduralParts
 
         private SRBBellConfig selectedBell;
         private Dictionary<string, SRBBellConfig> srbConfigs;
-        [SerializeField]
-        public ConfigNode[] srbConfigsSerialized;
+        
+        private static ConfigNode[] srbConfigsSerialized;
 
         [Serializable]
         public class SRBBellConfig : IConfigNode

--- a/Source/zzVersionChecker.cs
+++ b/Source/zzVersionChecker.cs
@@ -65,7 +65,7 @@ namespace ProceduralParts
             // Even if you don't lock down functionality, you should return true if your users
             // can expect a future update to be available.
             //
-            return Versioning.version_major == 1 && Versioning.version_minor == 0 && Versioning.Revision == 0;
+            return Versioning.version_major == 1 && Versioning.version_minor == 0 && Versioning.Revision == 2;
 
             /*-----------------------------------------------*\
             | IMPLEMENTERS SHOULD NOT EDIT BEYOND THIS POINT! |


### PR DESCRIPTION
This is a fix for the long-standing problem where procedural components would lose track of parts that were attached to them, causing them to start floating. This is done thorough two methods:
1. The major issue was caused when the ship hadn't fully loaded and parts were attached before the shape had initialized the nodes, causing a null pointer exception. To fix this, we replay attach requests that were invalid once the shape has been initialized.
2. As a result of keeping track of node attachments through save/reload, children of SRBs would be attached to the base of the SRB shape. This was caused by the bell not having offset the node, and the node not knowing about the offset after the fact. To fix this, we modify the follower to keep a reference to the offset.
