### PR TITLE
Minor category changes

### DIFF
--- a/Parts/Deprecated/ConeLiquid.cfg
+++ b/Parts/Deprecated/ConeLiquid.cfg
@@ -22,7 +22,7 @@ PART
 	cost = 0 // 4000
 	TechRequired = stability
 	entryCost = 4000
-	category = Propulsion
+	category = FuelTank
 	subcategory = 0
 	title = Procedural Liquid Tank Cone
 	manufacturer = Kerbchem Industries
@@ -42,6 +42,16 @@ PART
 	breakingTorque = 200
 	maxTemp = 2000
 
+	RESOURCE {
+		name = LiquidFuel
+		amount = 34.63
+		maxAmount = 34.63
+	}
+	RESOURCE {
+		name = Oxidizer
+		amount = 42.32
+		maxAmount = 42.32
+	}
 
 	MODULE
 	{

--- a/Parts/Tanks/1TankLiquid.cfg
+++ b/Parts/Tanks/1TankLiquid.cfg
@@ -23,7 +23,7 @@ PART
 	cost = 0 // 4000
 	TechRequired = basicRocketry
 	entryCost = 4000
-	category = Propulsion
+	category = FuelTank
 	subcategory = 0
 	title = Procedural Liquid Tank
 	manufacturer = Kerbchem Industries
@@ -43,6 +43,16 @@ PART
 	breakingTorque = 200
 	maxTemp = 2000
 
+	RESOURCE {
+		name = LiquidFuel
+		amount = 96.22
+		maxAmount = 96.22
+	}
+	RESOURCE {
+		name = Oxidizer
+		amount = 117.6
+		maxAmount = 117.6
+	}
 
 	MODULE
 	{

--- a/Parts/Tanks/2TankRCS.cfg
+++ b/Parts/Tanks/2TankRCS.cfg
@@ -23,7 +23,7 @@ PART
 	cost = 0 // 4000
 	TechRequired = advFuelSystems
 	entryCost = 4000
-	category = Propulsion
+	category = FuelTank
 	subcategory = 0
 	title = Procedural RCS Tank
 	manufacturer = Kerbchem Industries
@@ -43,6 +43,12 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 	maxTemp = 2000
+	
+	RESOURCE {
+		name = MonoPropellant
+		amount = 135
+		maxAmount = 135
+	}
 
 	MODULE
 	{

--- a/Parts/Tanks/3TankXenon.cfg
+++ b/Parts/Tanks/3TankXenon.cfg
@@ -23,7 +23,7 @@ PART
 	cost = 0 // 4000
 	TechRequired = ionPropulsion
 	entryCost = 4000
-	category = Utility
+	category = FuelTank
 	subcategory = 0
 	title = Procedural Xenon Tank
 	manufacturer = Kerbchem Industries
@@ -43,6 +43,12 @@ PART
 	breakingForce = 50
 	breakingTorque = 50
 	maxTemp = 2000
+	
+	RESOURCE {
+		name = XenonGas
+		amount = 747.5
+		maxAmount = 747.5
+	}
 
 	MODULE
 	{

--- a/Parts/Tanks/4SRB.cfg
+++ b/Parts/Tanks/4SRB.cfg
@@ -78,6 +78,12 @@ PART
 	
 	stagingIcon = SOLID_BOOSTER
 	
+	RESOURCE {
+		name = SolidFuel
+		amount = 427.1
+		maxAmount = 427.1
+	}
+	
 	MODULE
 	{
 		name = ProceduralPart

--- a/Parts/Tanks/TankOre.cfg
+++ b/Parts/Tanks/TankOre.cfg
@@ -23,7 +23,7 @@ PART
 	cost = 0 // 4000
 	TechRequired = advScienceTech
 	entryCost = 4000
-	category = Utility
+	category = FuelTank
 	subcategory = 0
 	title = Procedural Ore Tank
 	manufacturer = Kerbchem Industries
@@ -43,6 +43,7 @@ PART
 	breakingTorque = 500
 	maxTemp = 2000
 
+	RESOURCE { name = Ore }
 
 	MODULE
 	{


### PR DESCRIPTION
I moved the procedural Ore and Xenon tanks over to the Fuel Tank tab, since that's where stock ore and xenon containers are placed. I also added resource nodes to each of the procedural parts so that you can find them in the Resource tab under the appropriate tags. I didn't touch the extra procedural parts for other mods.

I tested these changes in Sandbox Mode. I think the changes are simple enough not to cause any problems in Career/Science Mode that wouldn't be found in Sandbox Mode.
