### PR TITLE
Add RF ElectricPropulsion tanktype

### DIFF
--- a/Parts/ZOtherMods/RFTank.cfg
+++ b/Parts/ZOtherMods/RFTank.cfg
@@ -184,5 +184,6 @@ PART:NEEDS[RealFuels&!ModularFuelTanks]
 		typeAvailable = Balloon
 		typeAvailable = BalloonCryo
 		typeAvailable = Structural
+		typeAvailable = ElectricPropulsion
     }
 }


### PR DESCRIPTION
Allow the RF procedural parts tank to be used for xenon, argon etc. 
