### PR TITLE
Add cost for batteries

### DIFF
--- a/Parts/Electrical/Battery.cfg
+++ b/Parts/Electrical/Battery.cfg
@@ -45,7 +45,10 @@ PART
 	{
 		name = ProceduralPart
 		textureSet = BlueSide
-		
+		// added costPerkl otherwise procedural batteries cost nearly nothing
+		// using wrong calculated dryDensity = 0.1875 instead of 0.175 * 20000 = 3500
+		// 3500 would fit better with stock; larger batteries for same capacity and same costs
+		costPerkL = 3750	// based on dryDensity = 0.1875 (3750 U / kl) and simple number
 		diameterMin = 0.01
 		lengthMin = 0.01
 		volumeMin = 0.001
@@ -108,9 +111,11 @@ PART
 	{
 		name = ProceduralShapeCylinder
 		displayName = Cylinder
+		techRequired = basicScience
 		
-		length = 0.375
-		diameter = 0.375
+		// Z-100
+		length = 0.08691982 // density = 0.1875; 0.093128378 & density = 0.175
+		diameter = 0.625
 	}
 	MODULE 
 	{
@@ -151,15 +156,17 @@ PART
 		TANK_TYPE_OPTION 
 		{
 			name = Electric
-			// Dry density for the battery banks for Z-200 and Z-4k is 0.163, 
+			// Dry density for the battery banks for Z-200 is 0.163,
+			// for Z-4k is 0.173 (not 0.163), 
 			// and the Z-1k is 0.184. We want to keep this to some 'roundish'
 			// number so the max volumes don't end up as weird fractions of 
 			// pi, so will round it a bit.
-			dryDensity = 0.1875
+			dryDensity = 0.1875	// should be 0.175 resulting in more similar cylinders
 			RESOURCE 
 			{
 				name = ElectricCharge
 				// All stock parts are the same. This translates to 3500 U / kL
+				// 0.175 * 20000 = 3500 while 0.1875 * 20000 = 3750
 				unitsPerT = 20000
 			}
 		}

--- a/Parts/Electrical/BatteryStock.cfg
+++ b/Parts/Electrical/BatteryStock.cfg
@@ -1,0 +1,22 @@
+// adjust cost for stock batteries to reflect procedural batteries linear progression
+
+@PART[batteryPack]
+{
+	%cost = 100 // 80
+}
+@PART[batteryBankMini]
+{
+	%cost = 200 // 360
+}
+@PART[ksp_r_largeBatteryPack]
+{
+	%cost = 400 // 550
+}
+@PART[batteryBank]
+{
+	%cost = 1000 // 880
+}
+@PART[batteryBankLarge]
+{
+	%cost = 4000 // 4500
+}


### PR DESCRIPTION
Procedural batteries cost nearly nothing.
Using costPerkL will give them at least a linear progression.

Adjust stock batteries costing the same as procedural.
