### PR TITLE
Stop log spam

### DIFF
--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -1465,7 +1465,7 @@ namespace ProceduralParts
         {
             if (HighLogic.LoadedScene == GameScenes.EDITOR)
             {
-                Debug.Log("stdCost: " + stdCost);
+                //Debug.Log("stdCost: " + stdCost);
                 float cost = baseCost;
                 if ((object)shape != null)
                     cost += shape.GetCurrentCostMult() * shape.Volume * costPerkL;


### PR DESCRIPTION
I've been experiencing lots of "stdCost: 0" spam in my logs. It seems a debug log message was left active in a repeatedly called function for the 1.0.5 version. 

I wasn't able to build ProceduralParts with the makefile (don't have make or perl in environment) but I was able to build it after stripping a bunch of build steps and verified that the spam went away. The only change is a commented out Debug.Log call so I don't really think this could break anything, but in the interest of full disclosure.
