### PR TITLE
Fixes 0-radius stack attached parts from being sent to [NaN, NaN, NaN]

### DIFF
--- a/Source/ProceduralAbstractSoRShape.cs
+++ b/Source/ProceduralAbstractSoRShape.cs
@@ -183,7 +183,7 @@ namespace ProceduralParts
             }
 
             // sometimes, if the shapes radius is 0, r rersults in NaN
-            if (float.IsNaN(result.r))
+            if (float.IsNaN(result.r) || float.IsPositiveInfinity(result.r) || float.IsNegativeInfinity(result.r))
             {
                 result.r = 0;
             }
@@ -237,7 +237,7 @@ namespace ProceduralParts
             if (r > 0f)
             {
                 theta = Mathf.Atan2(-position.z, position.x);
-                phi = Mathf.Asin(position.y / r);
+                phi = Mathf.Asin(Mathf.Clamp(position.y / r, -1f, 1f));
             }
             else
             {
@@ -253,8 +253,8 @@ namespace ProceduralParts
             {
                 ProfilePoint topBot = (phi < 0) ? lastProfile.First.Value : lastProfile.Last.Value;
 
-                float tbR = Mathf.Sqrt(topBot.y * topBot.y + topBot.dia * topBot.dia * 0.25f);
-                float tbPhi = Mathf.Asin(topBot.y / tbR);
+                float tbR = Mathf.Sqrt(Mathf.Clamp(topBot.y * topBot.y + topBot.dia * topBot.dia * 0.25f, 0f, Mathf.Infinity));
+                float tbPhi = Mathf.Asin(Mathf.Clamp(topBot.y / tbR, -1f, 1f));
 
                 if (Mathf.Abs(phi) >= Mathf.Abs(tbPhi))
                 {

--- a/Source/ProceduralParts.csproj
+++ b/Source/ProceduralParts.csproj
@@ -44,16 +44,18 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\Games\KSP 1.0.5\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Games\KSP_090clean\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="KSPAPIExtensions">
-      <HintPath>..\..\..\..\Games\KSP 1.0.5\GameData\ProceduralParts\Plugins\KSPAPIExtensions.dll</HintPath>
+      <HintPath>..\..\KSPAPIExtensions\KSPAPIExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\Games\KSP 1.0.5\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Games\KSP_090clean\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -77,12 +79,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
+    <PostBuildEvent>rem copy /y "$(TargetPath)" "$(SolutionDir)..\Plugins\"
+rem if exist "$(SolutionDir)\KSPAPIExtensions.dll" move "$(SolutionDir)\KSPAPIExtensions.dll" "$(SolutionDir)..\Plugins\"
+cd "$(ProjectDir)"\..
+del "Plugins\System.Core.dll"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
+    <PreBuildEvent>cd "$(ProjectDir)"\..
+perl version-gen</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/ProceduralParts.csproj
+++ b/Source/ProceduralParts.csproj
@@ -44,18 +44,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\Games\KSP_090clean\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\Games\KSP 1.0.5\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="KSPAPIExtensions">
-      <HintPath>..\..\KSPAPIExtensions\KSPAPIExtensions.dll</HintPath>
+      <HintPath>..\..\..\..\Games\KSP 1.0.5\GameData\ProceduralParts\Plugins\KSPAPIExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Games\KSP_090clean\KSP_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\..\Games\KSP 1.0.5\KSP_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -79,14 +77,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>rem copy /y "$(TargetPath)" "$(SolutionDir)..\Plugins\"
-rem if exist "$(SolutionDir)\KSPAPIExtensions.dll" move "$(SolutionDir)\KSPAPIExtensions.dll" "$(SolutionDir)..\Plugins\"
-cd "$(ProjectDir)"\..
-del "Plugins\System.Core.dll"</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>cd "$(ProjectDir)"\..
-perl version-gen</PreBuildEvent>
+    <PreBuildEvent>
+    </PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/Properties/AssemblyInfo.in
+++ b/Source/Properties/AssemblyInfo.in
@@ -29,4 +29,3 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("@VERSION@")]

--- a/Source/Properties/AssemblyInfo.in
+++ b/Source/Properties/AssemblyInfo.in
@@ -29,3 +29,4 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
+[assembly: AssemblyVersion("@VERSION@")]

--- a/Source/TransformFollower.cs
+++ b/Source/TransformFollower.cs
@@ -99,7 +99,6 @@ namespace ProceduralParts
                 trans = transform.position - oldOffset;
                 oldOffset = transform.position;
             }
-
             target.Translate(trans);
         }
 


### PR DESCRIPTION
Should fix visits to NaN-space for vehicles where a part is attached to a proc part on the stack node where the proc part radius is 0.
