### PR TITLE
Provides USI-LS compatibility

### DIFF
--- a/Parts/ZOtherMods/USI-LS compatibility
+++ b/Parts/ZOtherMods/USI-LS compatibility
@@ -1,0 +1,191 @@
+PART:NEEDS[USILifeSupport]
+{
+	// --- general parameters ---
+	name = proceduralTankUSI-LS
+	module = Part
+	author = AncientGammoner, NathanKell, Swamp Ig, OtherBarry, RoverDude, Rafael acevedo
+
+	// --- asset parameters ---
+	MODEL
+	{
+		model = ProceduralParts/Parts/cylinderTank
+		scale = 1,1,1
+	}
+	scale = 1
+	rescaleFactor = 1
+
+	// --- node definitions ---
+	node_stack_top=0,0.5,0,0,1,0,1
+	node_stack_bottom=0,-0.5,0,0,-1,0,1
+	node_attach=0,0,0.5,0,0,-1,1
+
+	// --- editor parameters ---
+	cost = 0 // 4000
+	TechRequired = survivability
+	entryCost = 4000
+	category = Utility
+	subcategory = 0
+	title = Procedural Life Support Tank
+	manufacturer = Kerbchem Industries Life-Support Division
+	description = Made from viscoelastic nanopolymers (which were discovered by accident... growing in the back of the office mini-fridge) this tank can be stretched to accommodate life support needs in a range of diferent size and shapes. Hardens to a rigid structure before launch!
+
+	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	attachRules = 1,1,1,1,0
+
+	// --- standard part parameters ---
+	mass = 1
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 1
+	crashTolerance = 12
+	breakingForce = 500
+	breakingTorque = 500
+	maxTemp = 2000
+	bulkheadProfiles = size1, srf
+
+	MODULE
+	{
+		name = ProceduralPart
+		textureSet = Mu
+		
+		costPerkL=980
+		
+		TECHLIMIT {
+			name = survivability
+			diameterMin = 0.1
+			diameterMax = 1.5
+			lengthMin = 0.1
+			lengthMax = 0.5
+			volumeMin = 0.1
+			volumeMax = 1.0
+		}
+
+		TECHLIMIT {
+			name = heavyRocketry
+			diameterMax = 3.0
+			volumeMax = 3.0
+			lengthMax = 1.0
+		}
+
+		TECHLIMIT {
+			// Make everything unlimited for metaMaterials
+			name = metaMaterials
+			diameterMin = 0.01
+			diameterMax = Infinity
+			lengthMin = 0.01
+			lengthMax = Infinity
+			volumeMin = 0.01
+			volumeMax = Infinity
+		}
+	}
+	MODULE
+	{
+		name = ProceduralShapeCylinder
+		displayName = Cylinder
+		techRequired = start
+		
+		length = 0.25
+		diameter = 1.25
+	}
+	MODULE 
+	{
+		name = ProceduralShapeCone
+		displayName = Cone
+		techRequired = generalConstruction
+		
+		length = 1.0
+		topDiameter = 0.625
+		bottomDiameter = 1.25
+	}
+	MODULE 
+	{
+		name = ProceduralShapePill
+		displayName = Fillet Cylinder
+		techRequired = advConstruction
+		
+		length = 1.0
+		diameter = 1.25
+		fillet = 0.25
+	}
+	MODULE 
+	{
+		name = ProceduralShapeBezierCone
+		displayName = Smooth Cone
+		techRequired = advConstruction
+		
+		length = 1.0
+		topDiameter = 0.625
+		bottomDiameter = 1.25
+	}
+
+	MODULE
+	{
+		name = LifeSupportmodule
+	}
+		
+	MODULE
+	{
+		name = TankContentSwitcher
+		useVolume = true
+		
+		TANK_TYPE_OPTION 
+		{
+			name = LifeSupport
+			// This is the dry mass of the tank per kL of volume.
+			dryDensity = 0.18
+			RESOURCE 
+			{
+				name = Supplies
+				unitsPerKL = 849
+			}
+			RESOURCE 
+			{
+				name = Mulch
+				unitsPerKL = 16.8
+				forceEmpty = true
+			}
+			RESOURCE 
+			{
+				name = Fertilizer
+				unitsPerKL = 16.8
+			}
+		}
+		
+		TANK_TYPE_OPTION 
+		{
+			name = Mulch
+			dryDensity = 0.18
+			RESOURCE 
+			{
+				name = Mulch
+				unitsPerKL = 849
+				forceEmpty = true
+			}
+		}
+
+		TANK_TYPE_OPTION 
+		{
+			name = Supplies
+			dryDensity = 0.18
+			RESOURCE 
+			{
+				name = Supplies
+				unitsPerKL = 849
+				forceEmpty = False
+			}
+		}
+		
+		TANK_TYPE_OPTION 
+		{
+			name = Fertilizer
+			dryDensity = 0.18
+			RESOURCE 
+			{
+				name = Fertilizer
+				unitsPerKL = 849
+				forceEmpty = False
+			}
+		}
+	}
+}


### PR DESCRIPTION
This CFG File gives USI-Life support compatibility to procedural tanks, it is a heavy modification of the TACLS compatibility CFG file.  When the user has USI Life support installed in KSP this will give the player the option to create a tank carrying the different types of supplies for "roverdudes" USI-LS mod.  I have attempted to replicate as close as possible the capacities of "roverdudes" USI-LS parts to ensure that procedurally generated tanks are neither over or under powered.  I have tested the mod extensively and it works with the USI-LS and KSP with issues. please feel free to test
