### PR TITLE
Added nozzle deflection on procedural SRB

### DIFF
--- a/Source/KSPUtils.cs
+++ b/Source/KSPUtils.cs
@@ -99,6 +99,7 @@ namespace KSPAPIExtensions
 		/// </summary>
 		/// <param name="part">The part to find the original of</param>
 		/// <returns>The original part, or the part itself if it was the original part</returns>
+        [Obsolete("This don't seem to work with the current version of KSP", false)]
 		public static Part GetSymmetryCloneOriginal(this Part part)
 		{
 			if (!part.isClone || part.symmetryCounterparts == null || part.symmetryCounterparts.Count == 0)
@@ -114,10 +115,15 @@ namespace KSPAPIExtensions
 			return part;
 		}
 
-		/// <summary>
-		/// Find the relationship between two parts.
-		/// </summary>
-		public static PartRelationship RelationTo(this Part part, Part other)
+        public static bool IsSurfaceAttached(this Part part)
+        {
+            return part.srfAttachNode != null && part.srfAttachNode.attachedPart == part.parent;
+        }
+
+        /// <summary>
+        /// Find the relationship between two parts.
+        /// </summary>
+        public static PartRelationship RelationTo(this Part part, Part other)
 		{
 			if (other == null || part == null)
 				return PartRelationship.Unknown;

--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -141,7 +141,7 @@ namespace ProceduralParts
                 // delete the temporary collider, if there is one
                 Component.Destroy(tempCollider);
                 tempCollider = null;
-                Debug.Log("destroyed temporary collider");
+                //Debug.Log("destroyed temporary collider");
             }
 
             // Update internal state
@@ -1213,7 +1213,7 @@ namespace ProceduralParts
 			if (HighLogic.LoadedScene != GameScenes.EDITOR)
 				return;
 
-			Debug.Log ("PartChildAttached");
+			//Debug.Log ("PartChildAttached");
 
 			AttachNode node = child.findAttachNodeByPart(part);
 

--- a/Source/ProceduralParts.csproj
+++ b/Source/ProceduralParts.csproj
@@ -37,6 +37,23 @@
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoWarn>1607</NoWarn>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Release\</OutputPath>
+    <Optimize>true</Optimize>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">
       <Private>False</Private>

--- a/Source/ProceduralParts.sln
+++ b/Source/ProceduralParts.sln
@@ -1,26 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual C# Express 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProceduralParts", "ProceduralParts.csproj", "{BB7C12FE-8189-4A56-B058-58C1B7366E60}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Debug|x86.ActiveCfg = Debug|x86
 		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Debug|x86.Build.0 = Debug|x86
 		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Release|Any CPU.ActiveCfg = Release|x86
-		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Release|Mixed Platforms.Build.0 = Release|x86
 		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Release|x86.ActiveCfg = Release|x86
 		{BB7C12FE-8189-4A56-B058-58C1B7366E60}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/Source/ProceduralSRB.cs
+++ b/Source/ProceduralSRB.cs
@@ -91,11 +91,11 @@ namespace ProceduralParts
 
         //[PartMessageListener(typeof(PartResourceInitialAmountChanged), scenes: GameSceneFilter.AnyEditor)]
         //public void PartResourceChanged(PartResource resource, double amount)
-		[KSPEvent(guiActive = false, active = true)]
-		public void OnPartResourceInitialAmountChanged(BaseEventData data)
+        [KSPEvent(guiActive = false, active = true)]
+        public void OnPartResourceInitialAmountChanged(BaseEventData data)
         {
-			if (!HighLogic.LoadedSceneIsEditor)
-				return;
+            if (!HighLogic.LoadedSceneIsEditor)
+                return;
             if (selectedBell == null)
                 return;
 
@@ -107,13 +107,13 @@ namespace ProceduralParts
 
         //[PartMessageListener(typeof(PartAttachNodeSizeChanged), scenes: GameSceneFilter.AnyEditor)]
         //public void ChangeAttachNodeSize(AttachNode node, float minDia, float area)
-		[KSPEvent(guiActive = false, active = true)]
-		public void ChangeAttachNodeSize(BaseEventData data)
+        [KSPEvent(guiActive = false, active = true)]
+        public void ChangeAttachNodeSize(BaseEventData data)
         {
-			if (!HighLogic.LoadedSceneIsEditor)
-				return;
-			AttachNode node = data.Get<AttachNode> ("node");
-			float minDia = data.Get<float> ("minDia");
+            if (!HighLogic.LoadedSceneIsEditor)
+                return;
+            AttachNode node = data.Get<AttachNode>("node");
+            float minDia = data.Get<float>("minDia");
             // ReSharper disable once CompareOfFloatsByEqualityOperator
             if (node.id != bottomAttachNodeName || minDia == attachedEndSize)
                 return;
@@ -130,19 +130,19 @@ namespace ProceduralParts
         //    return thrust * 0.5f * costMultiplier;
         //}
 
-		#region IPartCostModifier implementation
+        #region IPartCostModifier implementation
 
-		public float GetModuleCost (float defaultCost, ModifierStagingSituation sit)
-		{
-			return thrust * 0.5f * costMultiplier;
-		}
+        public float GetModuleCost(float defaultCost, ModifierStagingSituation sit)
+        {
+            return thrust * 0.5f * costMultiplier;
+        }
 
-		public ModifierChangeWhen GetModuleCostChangeWhen ()
-		{
-			return ModifierChangeWhen.CONSTANTLY;
-		}
+        public ModifierChangeWhen GetModuleCostChangeWhen()
+        {
+            return ModifierChangeWhen.CONSTANTLY;
+        }
 
-		#endregion
+        #endregion
 
         #endregion
 
@@ -158,6 +158,7 @@ namespace ProceduralParts
         [KSPField]
         public string thrustVectorTransformName;
         private Transform thrustTransform;
+        private Transform bellTransform;
 
         private EngineWrapper _engineWrapper;
         private EngineWrapper Engine
@@ -184,7 +185,7 @@ namespace ProceduralParts
 
         private SRBBellConfig selectedBell;
         private Dictionary<string, SRBBellConfig> srbConfigs;
-        
+
         private static ConfigNode[] srbConfigsSerialized;
 
         [Serializable]
@@ -213,7 +214,7 @@ namespace ProceduralParts
             [Persistent]
             public float chokeEndRatio = 0.5f;
 
-            [Persistent] 
+            [Persistent]
             public string realFuelsEngineType;
 
             public void Load(ConfigNode node)
@@ -276,8 +277,11 @@ namespace ProceduralParts
                     break;
             }
 
-            Transform srbBell = part.FindModelTransform(srbBellName);
-            thrustTransform = srbBell.Find(thrustVectorTransformName);
+            bellTransform = part.FindModelTransform(srbBellName);
+            thrustTransform = bellTransform.Find(thrustVectorTransformName);
+            //startDirection = thrustTransform.localEulerAngles.z;
+            startDirection = bellTransform.localEulerAngles.z;
+
 
             foreach (SRBBellConfig conf in srbConfigs.Values)
             {
@@ -288,7 +292,7 @@ namespace ProceduralParts
                     srbConfigs.Remove(conf.modelName);
                     continue;
                 }
-                conf.model.transform.parent = srbBell;
+                conf.model.transform.parent = bellTransform;
 
                 conf.srbAttach = conf.model.Find(conf.srbAttachName);
                 if (conf.srbAttach == null)
@@ -300,7 +304,7 @@ namespace ProceduralParts
 
                 // Only enable the colider for flight mode. This prevents any surface attachments.
                 if (HighLogic.LoadedSceneIsEditor && conf.model.GetComponent<Collider>() != null)
-					Destroy(conf.model.GetComponent<Collider>());
+                    Destroy(conf.model.GetComponent<Collider>());
 
                 conf.model.gameObject.SetActive(false);
             }
@@ -318,7 +322,7 @@ namespace ProceduralParts
                 ModularEnginesChangeThrust = (Action<float>)Delegate.CreateDelegate(typeof(Action<float>), mEC, "ChangeThrust");
                 try
                 {
-                    ModularEnginesChangeEngineType = (Action<string>) Delegate.CreateDelegate(typeof (Action<string>), mEC, "ChangeEngineType");
+                    ModularEnginesChangeEngineType = (Action<string>)Delegate.CreateDelegate(typeof(Action<string>), mEC, "ChangeEngineType");
                 }
                 catch
                 {
@@ -373,8 +377,13 @@ namespace ProceduralParts
             {
                 // Attach the bell. In the config file this isn't in normalized position, move it into normalized position first.
                 print("*PP* Setting bell position: " + pPart.transform.TransformPoint(0, -0.5f, 0));
-                srbBell.position = pPart.transform.TransformPoint(0, -0.5f, 0);
-                pPart.AddAttachment(srbBell, true);
+                bellTransform.position = pPart.transform.TransformPoint(0, -0.5f, 0);
+
+                var bellRotation = bellTransform.eulerAngles;
+                bellRotation.z = startDirection - bellDirection;
+                bellTransform.localEulerAngles = bellRotation;
+
+                pPart.AddAttachment(bellTransform, true);
 
                 // Move the bottom attach node into position.
                 // This needs to be done in flight mode too for the joints to work correctly
@@ -396,8 +405,9 @@ namespace ProceduralParts
 
         private void UpdateBell()
         {
-            if (selectedBell == null || selectedBellName == selectedBell.name)
+            if (selectedBell == null || (selectedBellName == selectedBell.name && oldBellDirection == bellDirection))
                 return;
+
 
             SRBBellConfig oldSelectedBell = selectedBell;
 
@@ -411,11 +421,18 @@ namespace ProceduralParts
 
             oldSelectedBell.model.gameObject.SetActive(false);
 
+            var bellRotation = bellTransform.localEulerAngles;
+            bellRotation.z = startDirection - bellDirection;
+            bellTransform.localEulerAngles = bellRotation;
+
+
             MoveBottomAttachmentAndNode(selectedBell.srbAttach.position - oldSelectedBell.srbAttach.position);
 
             InitModulesFromBell();
 
             UpdateMaxThrust();
+
+            oldBellDirection = bellDirection;
         }
 
         private void InitModulesFromBell()
@@ -433,20 +450,21 @@ namespace ProceduralParts
 
         #endregion
 
-        #region Thrust 
+        #region Thrust
 
         // ReSharper disable once InconsistentNaming
         private bool UsingME
         {
             get { return ModularEnginesChangeThrust != null; }
         }
+
         // ReSharper disable once InconsistentNaming
         private Action<float> ModularEnginesChangeThrust;
         // ReSharper disable once InconsistentNaming
         private Action<string> ModularEnginesChangeEngineType;
 
         [KSPField(isPersistant = true, guiName = "Thrust", guiActive = false, guiActiveEditor = true, guiFormat = "F3", guiUnits = "N"),
-		 UI_FloatEdit(scene = UI_Scene.Editor, minValue = 1f, maxValue = float.PositiveInfinity, incrementLarge = 100f, incrementSmall = 10, incrementSlide = 1f, sigFigs = 3, unit="kN", useSI = true )]
+         UI_FloatEdit(scene = UI_Scene.Editor, minValue = 1f, maxValue = float.PositiveInfinity, incrementLarge = 100f, incrementSmall = 10, incrementSlide = 1f, sigFigs = 3, unit = "kN", useSI = true)]
         public float thrust = 250;
         private float oldThrust;
 
@@ -464,6 +482,13 @@ namespace ProceduralParts
         [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false, guiName = "Thrust")]
         public string thrustME;
 
+        [KSPField(isPersistant = true, guiName = "Direction", guiActive = false, guiActiveEditor = true, guiFormat = "F3", guiUnits = "°"),
+         UI_FloatEdit(scene = UI_Scene.Editor, minValue = -25f, maxValue = 25f, incrementLarge = 5f, incrementSmall = 1f, incrementSlide = 0.1f, sigFigs = 2, unit = "°")]
+        public float bellDirection = 0;
+        private float oldBellDirection;
+
+        private float startDirection = 0f;
+
         // ReSharper disable once InconsistentNaming
         [KSPField]
         public float thrust1m = 0;
@@ -473,8 +498,8 @@ namespace ProceduralParts
 
         // Real fuels integration
         //[PartMessageListener(typeof(PartEngineConfigChanged))]
-		[KSPEvent(guiActive = false, active = true)]
-		public void OnPartEngineConfigsChanged()
+        [KSPEvent(guiActive = false, active = true)]
+        public void OnPartEngineConfigsChanged()
         {
             UpdateMaxThrust();
         }
@@ -499,13 +524,13 @@ namespace ProceduralParts
                 if (solidFuel != null)
                 {
                     float isp0 = Engine.atmosphereCurve.Evaluate(0);
-                    float minBurnTime = (float) Math.Ceiling(isp0*solidFuel.maxAmount*solidFuel.info.density*Engine.g/maxThrust);
+                    float minBurnTime = (float)Math.Ceiling(isp0 * solidFuel.maxAmount * solidFuel.info.density * Engine.g / maxThrust);
 
                     ((UI_FloatEdit)Fields["burnTimeME"].uiControlEditor).minValue = minBurnTime;
 
                     // Keep the thrust constant, change the current burn time to match
                     // Don't round the value, this stops it jumping around and won't matter that much
-                    burnTimeME = (float)(isp0 * solidFuel.maxAmount * solidFuel.info.density * Engine.g / thrust);   
+                    burnTimeME = (float)(isp0 * solidFuel.maxAmount * solidFuel.info.density * Engine.g / thrust);
                 }
             }
 
@@ -515,7 +540,7 @@ namespace ProceduralParts
         private void UpdateThrust(bool force = false)
         {
             // ReSharper disable CompareOfFloatsByEqualityOperator
-            if (!force && oldThrust == thrust && burnTimeME == oldBurnTimeME)
+            if (!force && oldThrust == thrust && burnTimeME == oldBurnTimeME && oldBellDirection == bellDirection)
                 return;
             // ReSharper restore CompareOfFloatsByEqualityOperator
 
@@ -525,7 +550,8 @@ namespace ProceduralParts
 
             oldThrust = thrust;
             oldBurnTimeME = burnTimeME;
-            if(HighLogic.LoadedSceneIsEditor)
+
+            if (HighLogic.LoadedSceneIsEditor)
                 GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
         }
 
@@ -536,12 +562,11 @@ namespace ProceduralParts
         {
             PartResource solidFuel = part.Resources["SolidFuel"];
 
-            if(solidFuel != null)
+            if (solidFuel != null)
             {
                 float _burnTime = (float)(solidFuel.amount / (fuelRate / solidFuel.info.density));
                 burnTime = string.Format("{0:F1}s", _burnTime);
             }
-
         }
 
         private void UpdateThrustDependentCalcs()
@@ -552,7 +577,7 @@ namespace ProceduralParts
             if (solidFuel == null)
                 solidFuelMassG = UsingME ? 7.454 : 30.75;
             else
-                solidFuelMassG = solidFuel.amount*solidFuel.info.density*Engine.g;
+                solidFuelMassG = solidFuel.amount * solidFuel.info.density * Engine.g;
 
             FloatCurve atmosphereCurve = Engine.atmosphereCurve;
 
@@ -560,7 +585,7 @@ namespace ProceduralParts
             {
                 //float burnTime0 = burnTimeME = (float)(atmosphereCurve.Evaluate(0) * solidFuelMassG / thrust);
                 //float burnTime1 = (float)(atmosphereCurve.Evaluate(1) * solidFuelMassG / thrust);
-                
+
                 fuelRate = thrust / (atmosphereCurve.Evaluate(0f) * Engine.g);
                 if (solidFuel != null)
                 {
@@ -584,7 +609,7 @@ namespace ProceduralParts
 
                 thrustME = thrust0.ToStringSI(unit: "N", exponent: 3) + " Vac / " + thrust1.ToStringSI(unit: "N", exponent: 3) + " ASL";
                 srbISP = string.Format("{1:F0}s Vac / {0:F0}s ASL", atmosphereCurve.Evaluate(1), atmosphereCurve.Evaluate(0));
-                fuelRate = (float)solidFuelMassG / ( burnTimeME * Engine.g );
+                fuelRate = (float)solidFuelMassG / (burnTimeME * Engine.g);
             }
 
             // This equation is much easier. From StretchySRBs
@@ -608,7 +633,7 @@ namespace ProceduralParts
             Engine.maxThrust = thrust;
             //part.GetComponent<ModuleEngines>().maxFuelFlow = (float)(0.1*fuelRate);
             part.GetComponent<ModuleEngines>().maxFuelFlow = fuelRate;
-              
+
 
             selectedBell.model.transform.localScale = new Vector3(bellScale, bellScale, bellScale);
 
@@ -683,7 +708,7 @@ namespace ProceduralParts
                 num = 0f;
 
             Material mat = selectedBell.model.GetComponent<Renderer>().sharedMaterial;
-            mat.SetColor("_EmissiveColor", new Color(num*num, 0, 0));
+            mat.SetColor("_EmissiveColor", new Color(num * num, 0, 0));
         }
 
         #endregion

--- a/Source/ProceduralSRB.cs
+++ b/Source/ProceduralSRB.cs
@@ -33,6 +33,7 @@ namespace ProceduralParts
             {
                 if (GameSceneFilter.AnyInitializing.IsLoaded())
                     LoadBells(node);
+
             }
             catch (Exception ex)
             {
@@ -61,6 +62,7 @@ namespace ProceduralParts
             {
                 InitializeBells();
                 UpdateMaxThrust();
+
                 if (GameSceneFilter.AnyEditor.IsLoaded())
                     GameEvents.onEditorPartEvent.Add(OnEditorPartEvent);
             }
@@ -74,8 +76,7 @@ namespace ProceduralParts
 
         public void OnDestroy()
         {
-            if (GameSceneFilter.AnyEditor.IsLoaded())
-                GameEvents.onEditorPartEvent.Remove(OnEditorPartEvent);
+            GameEvents.onEditorPartEvent.Remove(OnEditorPartEvent);
         }
 
         public override void OnUpdate()
@@ -99,15 +100,21 @@ namespace ProceduralParts
             }
         }
 
-        public void OnEditorPartEvent(ConstructionEventType type, Part part)
+        public void OnEditorPartEvent(ConstructionEventType type, Part ePart)
         {
             if (!HighLogic.LoadedSceneIsEditor)
                 return;
 
-            if (part != this.part)
+            if (!(ePart == part || ePart.FindChildPart(part.name, true) != null))
                 return;
 
-            if (part != null && type != ConstructionEventType.PartDeleted)
+            //if (type != ConstructionEventType.PartDragging)
+                Debug.Log(string.Format("Editor event '{0}' for part {1} ({2})", type, ePart.name, ePart.GetInstanceID()));
+                
+
+            Debug.Log("isSymmetryOriginal (before) = " + isSymmetryOriginal);
+
+            if (ePart != null && type != ConstructionEventType.PartDeleted)
             {
                 if (type == ConstructionEventType.PartCopied ||
                     type == ConstructionEventType.PartCreated ||
@@ -127,6 +134,8 @@ namespace ProceduralParts
                         counterPart.GetComponent<ProceduralSRB>().SetBellRotation();
                 }
             }
+
+            Debug.Log("isSymmetryOriginal (after) = " + isSymmetryOriginal);
         }
 
         //[PartMessageListener(typeof(PartResourceInitialAmountChanged), scenes: GameSceneFilter.AnyEditor)]
@@ -477,6 +486,9 @@ namespace ProceduralParts
             {
                 if (bellTransform == null)
                     return;
+                Debug.Log("PP** SetBellRotation for part " + part.name);
+                Debug.Log("isSymmetryOriginal = " + isSymmetryOriginal);
+                Debug.Log("invertDeflection = " + invertDeflection);
 
                 bellTransform.localEulerAngles = Vector3.zero;
                 var rotAxis = Vector3.Cross(part.partTransform.right, part.partTransform.up);
@@ -547,7 +559,7 @@ namespace ProceduralParts
         [KSPField(isPersistant = false, guiActive = false, guiActiveEditor = false, guiName = "Thrust")]
         public string thrustME;
 
-        [KSPField(isPersistant = true, guiName = "Deflection angle", guiActive = false, guiActiveEditor = true, guiFormat = "F3", guiUnits = "°"),
+        [KSPField(isPersistant = true, guiName = "Deflection", guiActive = false, guiActiveEditor = true, guiFormat = "F3", guiUnits = "°"),
          UI_FloatEdit(scene = UI_Scene.Editor, minValue = -25f, maxValue = 25f, incrementLarge = 5f, incrementSmall = 1f, incrementSlide = 0.1f, sigFigs = 2, unit = "°")]
         public float thrustDeflection = 0;
         private float oldThrustDeflection;


### PR DESCRIPTION
At the request of Scott Manley in one of his latest video, I added nozzle deflection (thrust direction) on SRB. Feature was tested, symmetry works as expected. In case something break I also added an 'Invert' direction toggle (I added it at first because I had a lot of trouble making mirror symmetry work).
I also commented-out some Debug.Log to reduce spamming the debug console.
