### PR TITLE
Fixes for 1.2.0 Preview Release

### DIFF
--- a/Source/ProceduralHeatshield.cs
+++ b/Source/ProceduralHeatshield.cs
@@ -536,9 +536,9 @@ namespace ProceduralParts
         private void CopyNodeSizeAndStrength()
         {
             if (bottomNode == null)
-                bottomNode = part.findAttachNode(bottomNodeId);
+                bottomNode = part.FindAttachNode(bottomNodeId);
             if (topNode == null)
-                topNode = part.findAttachNode(topNodeId);
+                topNode = part.FindAttachNode(topNodeId);
             bottomNode.size = topNode.size;
             bottomNode.breakingForce = topNode.breakingForce;
             bottomNode.breakingTorque = topNode.breakingTorque;

--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -984,7 +984,7 @@ namespace ProceduralParts
         // ReSharper disable once InconsistentNaming
         public void AddNodeOffset(string nodeId, Func<Vector3> GetOffset)
         {
-            AttachNode node = part.findAttachNode(nodeId);
+            AttachNode node = part.FindAttachNode(nodeId);
             if (node == null)
                 throw new ArgumentException("Node " + nodeId + " is not the ID of an attachment node");
 
@@ -1215,7 +1215,7 @@ namespace ProceduralParts
 
 			Debug.Log ("PartChildAttached");
 
-			AttachNode node = child.findAttachNodeByPart(part);
+			AttachNode node = child.FindAttachNodeByPart(part);
 
 			if (shape == null || node == null) //OnUpdate hasn't fired or node not connected yet
             {
@@ -1263,7 +1263,7 @@ namespace ProceduralParts
                 case AttachModes.STACK:
                     newAttachment.Coordinates.RadiusMode = ProceduralAbstractShape.ShapeCoordinates.RMode.RELATIVE_TO_SHAPE_RADIUS;
 
-                    AttachNode ourNode = part.findAttachNodeByPart(child);
+                    AttachNode ourNode = part.FindAttachNodeByPart(child);
                     if (ourNode == null)
                     {
                         Debug.LogError("*ST* unable to find our node for child: " + child.transform);
@@ -1335,7 +1335,7 @@ namespace ProceduralParts
 			AttachNode childToParent = null;
 			if (newParent != null) 
 			{
-				childToParent = part.findAttachNodeByPart(newParent);
+				childToParent = part.FindAttachNodeByPart(newParent);
 			}
 
             if (shape == null || (newParent != null && childToParent == null)) //OnUpdate hasn't fired yet

--- a/Source/ProceduralSRB.cs
+++ b/Source/ProceduralSRB.cs
@@ -378,7 +378,7 @@ namespace ProceduralParts
 
                 // Move the bottom attach node into position.
                 // This needs to be done in flight mode too for the joints to work correctly
-                bottomAttachNode = part.findAttachNode(bottomAttachNodeName);
+                bottomAttachNode = part.FindAttachNode(bottomAttachNodeName);
                 Vector3 delta = selectedBell.srbAttach.position - selectedBell.model.position;
                 bottomAttachNode.originalPosition = bottomAttachNode.position += part.transform.InverseTransformDirection(delta);
 

--- a/Source/TankContentSwitcher.cs
+++ b/Source/TankContentSwitcher.cs
@@ -491,10 +491,10 @@ namespace ProceduralParts
                 if (keepAmount && selectedTankType.resources.Any(tr => tr.name == res.resourceName))
                     partResources.Add(res);
                 else
-                    Destroy(res);
+                    partResources.Remove(res);
             }
 
-            part.Resources.list.Clear();
+            part.Resources.dict.Clear();
 
             // Build them afresh. This way we don't need to do all the messing around with reflection
             // The downside is the UIPartActionWindow gets maked dirty and rebuit, so you can't use 
@@ -519,9 +519,6 @@ namespace ProceduralParts
                 node.AddValue("isTweakable", res.isTweakable);
                 part.AddResource(node);
             }
-
-            foreach (PartResource res in partResources)
-                Destroy(res);
 
             UIPartActionWindow window = part.FindActionWindow();
             if (window != null)

--- a/Source/zzVersionChecker.cs
+++ b/Source/zzVersionChecker.cs
@@ -65,7 +65,7 @@ namespace ProceduralParts
             // Even if you don't lock down functionality, you should return true if your users
             // can expect a future update to be available.
             //
-            return Versioning.version_major == 1 && Versioning.version_minor == 1 && Versioning.Revision == 2;
+            return Versioning.version_major == 1 && Versioning.version_minor == 2 && Versioning.Revision == 0;
 
             /*-----------------------------------------------*\
             | IMPLEMENTERS SHOULD NOT EDIT BEYOND THIS POINT! |


### PR DESCRIPTION
It seems PartResouce is no longer Destroyable.  I changed it to .Remove(res) from partResources and removed the final cycle of Destroying PartResouce in partResources

I changed the clearing of the resource list (part.Resources.list) to clear the dictionary (part.Resources.dict)

Below are just capitalization changes that have changed in 1.2.0
part.findAttachNode -> part.FindAttachNode
part.findAttachNodeByPart -> part.FindAttachNodeByPart
