### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,4 +347,3 @@ MigrationBackup/
 
 # macOS
 .DS_Store
-*.csproj


### PR DESCRIPTION
The .csproj file is a key part of the project and should **not** be gitignored.
@pap1723, I assume there was a reason this was done. I can attempt to advise a more correct solution if you can remember the circumstances. Source files that are edited to control the project do not belong in .gitignore.