### PR TITLE
Set field values before moving nodes

### DIFF
--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -90,7 +90,7 @@ namespace ProceduralParts
         #region Events
 
         // Find the ProceduralAbstractShape in Part p that is the same ProceduralAbstractShape as the param.
-        private ProceduralAbstractShape FindAbstractShapeModule(Part p, ProceduralAbstractShape type)
+        protected ProceduralAbstractShape FindAbstractShapeModule(Part p, ProceduralAbstractShape type)
         {
             foreach (ProceduralAbstractShape s in p.FindModulesImplementing<ProceduralAbstractShape>())
             {
@@ -237,6 +237,14 @@ namespace ProceduralParts
             float clampedScaledValue = Mathf.Clamp(scaledValue, minLength, maxLength);
             bool closeEnough = Mathf.Abs((clampedScaledValue / scaledValue) - 1) < 0.01;
             scaledField.SetValue(clampedScaledValue, this);
+            foreach (Part p in part.symmetryCounterparts)
+            {
+                // Propagate the change to other parts in symmetry group
+                if (FindAbstractShapeModule(p, this) is ProceduralAbstractShape pm)
+                {
+                    scaledField.SetValue(clampedScaledValue, pm);
+                }
+            }
             OnShapeDimensionChanged(scaledField, orig);
             MonoUtilities.RefreshPartContextWindow(part);
             return closeEnough;

--- a/Source/ProceduralShapePill.cs
+++ b/Source/ProceduralShapePill.cs
@@ -245,6 +245,14 @@ namespace ProceduralParts
             bool closeEnough = Mathf.Abs((clampedTargetLength / targetLength) - 1) < 0.01;
 
             field.SetValue(targetLength, this);
+            foreach (Part p in part.symmetryCounterparts)
+            {
+                // Propagate the change to other parts in symmetry group
+                if (FindAbstractShapeModule(p, this) is ProceduralAbstractShape pm)
+                {
+                    field.SetValue(targetLength, pm);
+                }
+            }
             OnShapeDimensionChanged(field, orig);
             MonoUtilities.RefreshPartContextWindow(part);
             return closeEnough;


### PR DESCRIPTION
## Background

I'm working on the rewrite of SmartTank (see HebaruSan/SmartTank#3), and I've got it largely working (with one exception to be described below). To review, SmartTank is a mod that builds upon ProceduralParts by adding the ability to automatically resize tanks to achieve particular TWR targets, using KSP's delta V calculation engine (fomerly using KER's). It can also automatically adjust the tank diameter to fit attached parts.

The approach I'm taking in the rewrite is to call `ProceduralPart.SeekVolume` to update the tank lengths, and `OnShapeDimensionChanged` of whichever shape class when I change the diameters.

## Problem

Placing procedural parts in symmetry while the above-described SmartTank rewrite is active results in incorrect placement of some of the attached parts:

![image](https://user-images.githubusercontent.com/1559108/96528657-eee71900-1248-11eb-9d01-30a11556be7e.png)

In this image, I first built a simple middle stage, then placed a pair of radial decouplers on it, then procedural tanks, then engines under the side tanks. The image is captured immediately after the engines are added. The tank on the right is translated about twice as far as it's supposed to be horizontally in response to the diameter changing from 1.25m to 2.5m, and the engine on the right is translated downwards twice as far as it's supposed to be in response to the length changing to match the target TWR.

## Cause

When the tanks are resized, the attach nodes have to be moved, and some of them are moving twice as far as they're supposed to. And it seems to only affect parts in symmetry. This suggests that the intended offset is being applied twice somehow for some parts in symmetry.

I tried a workaround in SmartTank code to update the size of _only one_ of the tanks in the symmetry group to see whether the changes would be applied to it by some part of ProceduralParts, but this only made the problem worse; the tanks ended up different sizes _and_ the attach nodes were still translated way off to the wrong place. After similarly failing in a few other workaround attempts, I started to dig into the PP code.

I think the duplicate call is in `ProceduralAbstractShape.OnShapeDimensionChanged`, which first calls `TranslateAttachmentsAndNodes` for the current part and then for all the other parts in its symmetry group. If you call `SeekVolume` for each part in a symmetry group, `TranslateAttachmentsAndNodes` is called multiple times for each of them. `TranslateAttachmentsAndNodes` works with relative position offsets rather than absolute, so the "extra" calls move the nodes further out by the same amount each time.

## Changes

~~Now `ProceduralAbstractShape.OnShapeDimensionChanged` no longer calls `TranslateAttachmentsAndNodes` for other parts in symmetry with the current part; it will only be called when we are actually setting the size of the tank. In my testing this one change completely solves the above issue and makes SmartTank work flawlessly.~~

~~If this change breaks something else in ProceduralParts, please let me know, and I'll have another look at it with that broken thing in mind. If it looks OK, then I'd kindly request a new release be made before too long, so I can release the SmartTank rewrite to work alongside it.~~

Now `ProceduralAbstractShape.SeekVolume` and `ProceduralShapePill.SeekVolume` propagate field changes before the nodes are moved. This ensures that the nodes are moved to the correct place for length changes. The fix for diameter changes will be done in SmartTank by only calling `OnShapeDimensionChanged` once per symmetry group.

Tagging @DRVeyl in hopes of starting a conversation about this proposal.