### PR TITLE
proceduralPaint

### DIFF
--- a/GameData/ProceduralParts/Parts/Structural/Paint.cfg
+++ b/GameData/ProceduralParts/Parts/Structural/Paint.cfg
@@ -1,0 +1,115 @@
+// TODO: derive from proceduralTank, like procStructural?
+// starting from scratch seemed a more straightforward way to avoid
+// pulling in unexpected bits
+PART
+{
+	name = proceduralPaint
+	module = Part
+	author = lpg
+
+	scale = 1
+	rescaleFactor = 1
+
+	title = Procedural Paint Job
+	description = A massless, physicsless part that can be recolored and reshaped
+	manufacturer = Kerbchem Industries
+	TechRequired = start
+	category = Utility
+	subcategory = 0
+	cost = 0
+	entryCost = 1
+	tags = proc, procedural
+
+	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	// we want surface-attachable and nothing attachable to it.
+	// dunno what allowCollisions is for, but we don't want collisions.
+	attachRules = 0,1,0,0,0
+	// TODO: try to make it center-attachable instead of side-attachable.
+        // can't make sense of how these behave.
+	node_attach=0,0,0.5,0,0,-1,1
+
+	mass = 0.0001
+
+	// don't break, don't burn
+	crashTolerance = 100
+	breakingForce = 2000
+	breakingTorque = 2000
+	maxTemp = 3000
+	skinMaxTemp = 3000
+
+	RP0conf = true
+
+	MODEL
+	{
+		model = ProceduralParts/Parts/cylinderTank
+		scale = 1,1,1
+	}
+	MODULE
+	{
+		name = ProceduralPart
+		textureSet = WhiteSide
+		costPerkL = 0.5
+		
+	}
+	MODULE
+	{
+		name = ProceduralShapeCylinder
+		displayName = Cylinder
+		techRequired = start
+		
+		length = 1.0
+		diameter = 1.0
+	}
+	MODULE 
+	{
+		name = ProceduralShapeCone
+		displayName = Cone
+		techRequired = generalConstruction
+		
+		length = 1.0
+		topDiameter = 0.5
+		bottomDiameter = 1.0
+	}
+	MODULE 
+	{
+		name = ProceduralShapePill
+		displayName = Fillet Cylinder
+		techRequired = advConstruction
+		
+		length = 1.0
+		diameter = 1.0
+		fillet = 0.25
+	}
+	MODULE 
+	{
+		name = ProceduralShapeBezierCone
+		displayName = Smooth Cone
+		techRequired = advConstruction
+		
+		selectedShape = Round #1
+		length = 1.0
+		topDiameter = 0.5
+		bottomDiameter = 1.0
+	}
+	MODULE
+	{
+		name = ProceduralShapePolygon
+		displayName = Polygon
+		techRequired = start
+		
+		length = 1.0
+		diameter = 1.0
+	}
+}
+@PART[proceduralPaint]:FINAL // FIXME: there's probably a better choice than FINAL. How does FAR arrange to run after parts are defined?
+{
+	// make FAR ignore us. Seems to work but don't know why.
+	!MODULE[GeometryPartModule] {}
+}
+@PART[proceduralPaint]:AFTER[RealismOverhaul]
+{
+	// may or may not be the right way to make a part physicsless. With a mass of 0, not sure it even matters
+	// AFTER[RO] because RO forces it to 0
+	PhysicsSignificance = 1
+}
+


### PR DESCRIPTION
A massless, physicsless part that can be recolored and reshaped. To add greeble without paying for it too much.

Not quite merge-ready, but I don't anticipate taking the time to finish polishing it. Maybe someone else will.

in particular, the FINAL probably ought to be changed.

My original idea was that the part would also be collider-less, but no idea if that's at all possible. So it's technically possible to use these as massless proc-structural parts, which isn't the intent. This is mitigated by preventing attaching other parts to it; but the end result is a neither-fish-nor-fowl part that's maybe too weird for general use.