### PR TITLE
Set PartUpgradesInSandbox setting on init

### DIFF
--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -58,6 +58,8 @@ namespace ProceduralParts
             installedFAR = AssemblyLoader.loadedAssemblies.Any(a => a.assembly.GetName().Name == "FerramAerospaceResearch");
             installedTU = AssemblyLoader.loadedAssemblies.Any(a => a.assembly.GetName().Name == "TexturesUnlimited");
             TextureSet.LoadTextureSets(LegacyTextureHandler.textureSets);
+            // "All Part Upgrades Applied In Sandbox" required for this mod to be usable in sandbox
+            HighLogic.CurrentGame.Parameters.CustomParams<GameParameters.AdvancedParams>().PartUpgradesInSandbox = true;
             staticallyInitialized = true;
         }
 


### PR DESCRIPTION
## Problem

Users of this mod continue to be very confused by unexpected procedural part size limitations in sandbox:

![image](https://user-images.githubusercontent.com/1559108/115095622-70c2b100-9f11-11eb-8d2d-b16baf1b666d.png)

![image](https://user-images.githubusercontent.com/1559108/115095655-9354ca00-9f11-11eb-9b06-909735e35759.png)

![image](https://user-images.githubusercontent.com/1559108/115095667-9e0f5f00-9f11-11eb-874e-d24ac59398e4.png)

## Causes

- ProceduralParts uses part upgrades to unlock certain limits on part size.
- The stock game, contrary to all logic and common sense, does _not_ enable all part upgrades by default in sandbox. Instead, it has a setting, "All Part Upgrades Applied In Sandbox", that unlocks part upgrades in sandbox.

These two things together mean that ProceduralParts has very surprising behavior in sandbox. Where the user expects to be able to build whatever they want in sandbox, instead they have some very small parts that can't be enlarged, ever, if they don't know about the setting.

## Changes

Now this setting will be set to true programmatically during initialization. There's no reason a user would want it set to false, and setting it to true does nothing other than what the user expects anyway, so this should be fine. Consider it a workaround for a very poor design decision in stock.

Pinging @DRVeyl in hopes of starting a conversation about addressing this.