### PR TITLE
Increase version to max 1.12

### DIFF
--- a/GameData/ProceduralParts/ProceduralParts.version
+++ b/GameData/ProceduralParts/ProceduralParts.version
@@ -25,7 +25,7 @@
     },
     "KSP_VERSION_MAX": {
         "MAJOR": "1",
-        "MINOR": "11",
+        "MINOR": "12",
         "PATCH": "99"
     }
 }


### PR DESCRIPTION
I'm not aware of any reason this would fail in 1.12, but I noticed the version is still at 1.11 max.