### PR TITLE
Change postBuild output to be within the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+*.dll
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/Source/ProceduralParts.csproj
+++ b/Source/ProceduralParts.csproj
@@ -131,8 +131,8 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
-      xcopy /Y "$(TargetPath)" "(ProjectDir)..\..\..\..\..\GameData\ProceduralParts\Plugins"
-      xcopy /Y "$(TargetDir)$(TargetName).pdb" "(ProjectDir)..\..\..\..\..\GameData\ProceduralParts\Plugins"
+      xcopy /Y "$(TargetPath)" "$(ProjectDir)..\GameData\ProceduralParts\Plugins\"
+      xcopy /Y "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)..\GameData\ProceduralParts\Plugins\"
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>

--- a/Source/ProceduralParts.csproj
+++ b/Source/ProceduralParts.csproj
@@ -130,9 +130,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program - 1.8.1 Dev\GameData\ProceduralParts\Plugins\"
-xcopy /Y "$(TargetDir)$(TargetName).pdb" "C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program - 1.8.1 Dev\GameData\ProceduralParts\Plugins\"
-</PostBuildEvent>
+    <PostBuildEvent>
+      xcopy /Y "$(TargetPath)" "..\..\..\GameData\ProceduralParts\Plugins"
+      xcopy /Y "$(TargetDir)$(TargetName).pdb" "..\..\..\GameData\ProceduralParts\Plugins"
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>

--- a/Source/ProceduralParts.csproj
+++ b/Source/ProceduralParts.csproj
@@ -131,8 +131,8 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
-      xcopy /Y "$(TargetPath)" "..\..\..\GameData\ProceduralParts\Plugins"
-      xcopy /Y "$(TargetDir)$(TargetName).pdb" "..\..\..\GameData\ProceduralParts\Plugins"
+      xcopy /Y "$(TargetPath)" "(ProjectDir)..\..\..\..\..\GameData\ProceduralParts\Plugins"
+      xcopy /Y "$(TargetDir)$(TargetName).pdb" "(ProjectDir)..\..\..\..\..\GameData\ProceduralParts\Plugins"
     </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
The old setup was user specific; a symbolic link can be set up to auto update the mod in a user dev install instead