### PR TITLE
Fix dry mass displaying old value in PAW

### DIFF
--- a/Source/TankContentSwitcher.cs
+++ b/Source/TankContentSwitcher.cs
@@ -305,7 +305,7 @@ namespace ProceduralParts
                 float totalMass = mass + Convert.ToSingle(resourceMass);
                 massDisplay = (SelectedTankType.isStructural) ?
                                 MathUtils.FormatMass(totalMass) :
-                                $"Dry: {MathUtils.FormatMass(part.mass)} / Wet: {MathUtils.FormatMass(totalMass)}";
+                                $"Dry: {MathUtils.FormatMass(mass)} / Wet: {MathUtils.FormatMass(totalMass)}";
             }
         }
 


### PR DESCRIPTION
Sometimes changing a tank's contents also changes its dry mass, e.g., when using Nertea's CryoTanks.  The old code displays the dry mass for the previous contents rather than the current contents.  In the following screenshot, the PAW is displaying the dry mass for hydrolox (the previous option in the switcher) rather than LH2 only (the current setup).

![bug](https://user-images.githubusercontent.com/11653155/153339880-f09bbc3f-838e-4d9c-a03f-f6bfb12b2ec0.png)

Here it is fixed by my tiny edit:

![fixed](https://user-images.githubusercontent.com/11653155/153340074-5fd16612-3301-4727-ac58-1e73f54da0df.png)

I don't know why _part.mass_ gives stale data, but AFAICS there's no benefit to using _part.mass_ over _mass_ so I didn't bother investigating that further.