### PR TITLE
Add KSPAssembly, repair version-gen, cross platform build

### DIFF
--- a/GameData/ProceduralParts/ProceduralParts.version
+++ b/GameData/ProceduralParts/ProceduralParts.version
@@ -1,31 +1,31 @@
 {
-   "NAME" : "Procedural Parts",
-   "URL" : "https://raw.githubusercontent.com/KSP-RO/ProceduralParts/master/GameData/ProceduralParts/ProceduralParts.version",
-   "DOWNLOAD" : "https://github.com/KSP-RO/ProceduralParts/releases",
-   "GITHUB" : {
-      "USERNAME"            : "KSP-RO",
-      "REPOSITORY"          : "ProceduralParts",
-      "ALLOW_PRE_RELEASE"   : false
-   },
-   "VERSION" : {
-      "MAJOR" : 2,
-      "MINOR" : 4,
-      "PATCH" : 3,
-      "BUILD" : 0
-   },
-   "KSP_VERSION" : {
-        "MAJOR": "1",
-        "MINOR": "8",
-        "PATCH": "1"
+    "NAME": "Procedural Parts",
+    "URL": "https://raw.githubusercontent.com/KSP-RO/ProceduralParts/master/GameData/ProceduralParts/ProceduralParts.version",
+    "DOWNLOAD": "https://github.com/KSP-RO/ProceduralParts/releases",
+    "GITHUB": {
+        "USERNAME": "KSP-RO",
+        "REPOSITORY": "ProceduralParts",
+        "ALLOW_PRE_RELEASE": false
+    },
+    "VERSION": {
+        "MAJOR": 2,
+        "MINOR": 4,
+        "PATCH": 3,
+        "BUILD": 0
+    },
+    "KSP_VERSION": {
+        "MAJOR": 1,
+        "MINOR": 8,
+        "PATCH": 1
     },
     "KSP_VERSION_MIN": {
-        "MAJOR": "1",
-        "MINOR": "8",
-        "PATCH": "1"
+        "MAJOR": 1,
+        "MINOR": 8,
+        "PATCH": 1
     },
     "KSP_VERSION_MAX": {
-        "MAJOR": "1",
-        "MINOR": "12",
-        "PATCH": "99"
+        "MAJOR": 1,
+        "MINOR": 12,
+        "PATCH": 99
     }
 }

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -21,7 +21,6 @@ TARGETS		:= ProceduralParts.dll
 
 API_FILES := \
 	DecouplerTweaker.cs \
-	ObjectSerializer.cs \
 	ProceduralAbstractShape.cs \
 	ProceduralAbstractSoRShape.cs \
 	ProceduralHeatshield.cs \
@@ -33,13 +32,12 @@ API_FILES := \
 	ProceduralSRB.cs \
 	TankContentSwitcher.cs \
 	TransformFollower.cs \
-	zzVersionChecker.cs \
 	ICostModifier.cs \
 	VectorUtils.cs \
 	$e
 
 RESGEN2	:= resgen2
-GMCS	:= gmcs
+GMCS	:= csc
 GIT		:= git
 TAR		:= tar
 ZIP		:= zip

--- a/Source/ProceduralParts.csproj
+++ b/Source/ProceduralParts.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -130,21 +130,11 @@
     <Compile Include="MathUtils.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-      xcopy /Y "$(TargetPath)" "$(ProjectDir)..\GameData\ProceduralParts\Plugins\"
-      xcopy /Y "$(TargetDir)$(TargetName).pdb" "$(ProjectDir)..\GameData\ProceduralParts\Plugins\"
-    </PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <Target Name="CopyOutput" AfterTargets="Build">
+    <ItemGroup>
+      <OutputFiles Include="$(TargetPath);$(TargetDir)$(TargetName).pdb"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(OutputFiles)"
+          DestinationFolder="$(ProjectDir)..\GameData\ProceduralParts\Plugins\"/>
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -22,6 +22,8 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a1c9118f-14a4-4aaf-bb43-87b1c13a7d4d")]
 
+[assembly: KSPAssembly("ProceduralParts", 2, 4)]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
@@ -30,4 +32,4 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.4.3.0")]
+[assembly: AssemblyFileVersion("2.4.3.1")]

--- a/Source/Properties/AssemblyInfo.in
+++ b/Source/Properties/AssemblyInfo.in
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -22,11 +22,14 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a1c9118f-14a4-4aaf-bb43-87b1c13a7d4d")]
 
+[assembly: KSPAssembly("ProceduralParts", @VERSION_MAJOR@, @VERSION_MINOR@)]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("@VERSION@")]
+[assembly: AssemblyVersion("@VERSION_MAJOR_FIRST@")]
+[assembly: AssemblyFileVersion("@VERSION@")]

--- a/version-gen
+++ b/version-gen
@@ -5,6 +5,7 @@ use warnings;
 use autodie;
 use FindBin qw($Bin);
 use JSON::PP;
+use Tie::IxHash;
 
 # Write various version things for ProceduralParts.
 # Paul Fenwick, January 2015.
@@ -13,32 +14,43 @@ use JSON::PP;
 # This requires JSON::PP to run, which comes with Perl since v5.14, or can be
 # installed with `cpanm JSON::PP`.
 
-my $VERSION_FILE      = "ProceduralParts.version";
+my $VERSION_FILE      = "GameData/ProceduralParts/ProceduralParts.version";
 my $ASSEMBLY_TEMPLATE = "Source/Properties/AssemblyInfo.in";
 my $ASSEMBLY_FILE     = "Source/Properties/AssemblyInfo.cs";
 
-# Here's our base metadata. We'll add VERSION info to this before outputting.
-my $metadata = {
-    NAME => "Procedural Parts",
-    URL  => "https://raw.githubusercontent.com/Swamp-Ig/ProceduralParts/master/ProceduralParts.version",
-	DOWNLOAD => "https://github.com/Swamp-Ig/ProceduralParts/releases",
-	GITHUB =>
-	{
-		USERNAME => "Swamp-Ig",
-		REPOSITORY => "ProceduralParts"
+# Fix the interface of Tie::IxHash to preserve key order
+sub tied_hash_ref {
+    tie(my %hash, 'Tie::IxHash', @_);
+    return \%hash;
+}
 
-	},
-    KSP_VERSION_MIN => {
+# Here's our base metadata. We'll add VERSION info to this before outputting.
+my $metadata = tied_hash_ref(
+    NAME => "Procedural Parts",
+    URL  => "https://raw.githubusercontent.com/KSP-RO/ProceduralParts/master/GameData/ProceduralParts/ProceduralParts.version",
+	DOWNLOAD => "https://github.com/KSP-RO/ProceduralParts/releases",
+	GITHUB => tied_hash_ref(
+		USERNAME   => "KSP-RO",
+		REPOSITORY => "ProceduralParts",
+        ALLOW_PRE_RELEASE => JSON::PP::false,
+    ),
+    VERSION => tied_hash_ref(),
+    KSP_VERSION => tied_hash_ref(
         MAJOR => 1,
-        MINOR => 3,
-        PATCH => 0
-	},
-    KSP_VERSION_MAX => {
-        MAJOR => 1,
-        MINOR => 3,
+        MINOR => 8,
         PATCH => 1
-    },
-};
+    ),
+    KSP_VERSION_MIN => tied_hash_ref(
+        MAJOR => 1,
+        MINOR => 8,
+        PATCH => 1
+	),
+    KSP_VERSION_MAX => tied_hash_ref(
+        MAJOR => 1,
+        MINOR => 12,
+        PATCH => 99
+    ),
+);
 
 chdir($Bin);
 
@@ -58,34 +70,38 @@ if ($version !~ m{
 }
 
 my $assembly_version = "$+{major}.$+{minor}.$+{patch}.$+{build}";
+my $assembly_version_major = "$+{major}";
+my $assembly_version_minor = "$+{minor}";
+my $assembly_version_major_first = "$+{major}.0.0.0";
 
 say "Writing metadata for version $assembly_version";
 
 # Using `int` below forces Perl to internally represent these as numbers,
 # even though they were the result of a string operation. This means no
 # unsightly quotes in the output JSON.
-
-$metadata->{VERSION} = {
+$metadata->{VERSION} = tied_hash_ref(
     MAJOR => int $+{major},
     MINOR => int $+{minor},
     PATCH => int $+{patch},
-    BUILD => 0              # If used, AVC could try to get the user to
-                            # install git builds, which we don't want.
-};
+    # If used, AVC could try to get the user to
+    # install git builds, which we don't want.
+    BUILD => 0
+);
 
 # Write our AVC metadata
-
 open(my $version_fh, '>', $VERSION_FILE);
-say {$version_fh} JSON::PP->new->pretty->encode( $metadata );
+print {$version_fh} JSON::PP->new->indent->indent_length(4)->space_after->encode( $metadata );
 close $version_fh;
 
 # Write our AssemblyInfo
-
 open(my $template_fh, '<', $ASSEMBLY_TEMPLATE);
 open(my $assembly_fh, '>', $ASSEMBLY_FILE);
 
 while (<$template_fh>) {
     s{\@VERSION\@}{$assembly_version};
+    s{\@VERSION_MAJOR_FIRST\@}{$assembly_version_major_first};
+    s{\@VERSION_MAJOR\@}{$assembly_version_major};
+    s{\@VERSION_MINOR\@}{$assembly_version_minor};
     print {$assembly_fh} $_;
 }
 


### PR DESCRIPTION
- `KSPAssembly` is now added to `AssemblyInfo.cs` so other mods (such as SmartTank) can use `KSPAssemblyDependency` to indicate a dependency on this mod
- Since it looks like this is generated from `AssemblyInfo.in`, this is updated as well
- The `version-gen` script is updated to generate correct output in the right places
  - `Tie::IxHash` is used to print the keys in the right order
  - The output path of the version file is updated to where it lives now
  - Compatibility in the script is updated to 1.8.1–1.12.99
  - The new `@VERSION_MAJOR@`, `@VERSION_MINOR@`, and `@VERSION_MAJOR_FIRST@` variables in `AssemblyInfo.in` are now substituted
- The version file is regenerated by the script with more consistent formatting
  - Indenting with 4 spaces
  - No spaces before colons
  - No quotes around numbers
- The `Makefile` no longer references two files that were deleted
- The `Makefile` now uses the current C# compiler `csc` rather than the very old and deprecated `gmcs`
- The `csproj`'s Windows-specific `xcopy` `<PostBuildEvent/>` is replaced with a cross-platform `<Target/>` that uses `<Copy/>` to do the same thing but works on all platforms

Tagging @NathanKell and @StonesmileGit in case GitHub doesn't send notifications for this.