### PR TITLE
Pass non-zero length to node translation from truss shape

### DIFF
--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -141,8 +141,8 @@ namespace ProceduralParts
             float trans = length - oldLength;
             foreach (AttachNode node in part.attachNodes)
             {
-                // Our nodes are relative to part center 0,0,0.  position.y > 0 are top nodes.
-                float direction = (node.position.y > 0) ? 1 : -1;
+                // Compare node id to 'top'. Names are top and bottom
+                float direction = (node.id == "top") ? 1 : -1;
                 Vector3 translation = direction * (trans / 2) * Vector3.up;
                 if (node.nodeType == AttachNode.NodeType.Stack)
                 {

--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -141,8 +141,8 @@ namespace ProceduralParts
             float trans = length - oldLength;
             foreach (AttachNode node in part.attachNodes)
             {
-                // Compare node id to 'top'. Names are top and bottom
-                float direction = (node.id == "top") ? 1 : -1;
+                // Our nodes are relative to part center 0,0,0.  position.y > 0 are top nodes.
+                float direction = (node.position.y > 0) ? 1 : -1;
                 Vector3 translation = direction * (trans / 2) * Vector3.up;
                 if (node.nodeType == AttachNode.NodeType.Stack)
                 {

--- a/Source/ProceduralShapeHollowTruss.cs
+++ b/Source/ProceduralShapeHollowTruss.cs
@@ -153,7 +153,9 @@ namespace ProceduralParts
             }
             if (f.name == nameof(length) && obj is float oldLength)
             {
-                HandleLengthChange(length, oldLength);
+                // Make sure to not pass a length of 0, as that breaks the direction selection in the method called.
+                float nodeLength = Mathf.Max(0.00001f, length);
+                HandleLengthChange(nodeLength, oldLength);
             }
         }
 


### PR DESCRIPTION
Current use of `y > 0` causes issues with the truss, which can be set to 0 length, resulting in the top node being stuck at the bottom. Preventing a truss length of 0 to be passed to the method fixes this.
Fixes #330 