### PR TITLE
Enable drag cube generation in editor if FAR is installed

### DIFF
--- a/GameData/ProceduralParts/Parts/Electrical/Battery.cfg
+++ b/GameData/ProceduralParts/Parts/Electrical/Battery.cfg
@@ -54,6 +54,7 @@ PART
 		diameterMax = 0.5
 		lengthMax = 1.0
 		volumeMax = 0.04	// 0.04 supports 150
+		updateDragCubesInEditor:NEEDS[FerramAerospaceResearch] = true
 
 		UPGRADES
 		{

--- a/GameData/ProceduralParts/Parts/Structural/Heatshield.cfg
+++ b/GameData/ProceduralParts/Parts/Structural/Heatshield.cfg
@@ -62,6 +62,7 @@ PART
 		lengthMax = 0.5
 		volumeMax = Infinity
 		allowCurveTweaking = False
+		updateDragCubesInEditor:NEEDS[FerramAerospaceResearch] = true
 
 		costsIncludeResources = false
 		baseCost=1

--- a/GameData/ProceduralParts/Parts/Structural/StackDecoupler.cfg
+++ b/GameData/ProceduralParts/Parts/Structural/StackDecoupler.cfg
@@ -61,6 +61,7 @@ PART
 		diameterMax = 1.75
 		lengthMax = 0.2
 		volumeMax = Infinity
+		updateDragCubesInEditor:NEEDS[FerramAerospaceResearch] = true
 
 		// If you want to be able to tweak the fillet curve, comment this line
 		allowCurveTweaking = false

--- a/GameData/ProceduralParts/Parts/Tanks/1TankLiquid.cfg
+++ b/GameData/ProceduralParts/Parts/Tanks/1TankLiquid.cfg
@@ -56,6 +56,7 @@ PART
 		lengthMax = 0.75
 		volumeMin = 0.6
 		volumeMax = 0.8
+		updateDragCubesInEditor:NEEDS[FerramAerospaceResearch] = true
 
 		UPGRADES
 		{

--- a/GameData/ProceduralParts/Parts/Tanks/4SRB.cfg
+++ b/GameData/ProceduralParts/Parts/Tanks/4SRB.cfg
@@ -100,6 +100,7 @@ PART
 		lengthMax = 1.25
 		volumeMin = 1.0
 		volumeMax = 2.0
+		updateDragCubesInEditor:NEEDS[FerramAerospaceResearch] = true
 
 		UPGRADES
 		{

--- a/GameData/ProceduralParts/Parts/ZOtherMods/TankExtraplanetary.cfg
+++ b/GameData/ProceduralParts/Parts/ZOtherMods/TankExtraplanetary.cfg
@@ -19,6 +19,7 @@
 		lengthMax = 5.0
 		volumeMin = 0.1
 		volumeMax = 15.0
+		updateDragCubesInEditor:NEEDS[FerramAerospaceResearch] = true
 
 		UPGRADES
 		{

--- a/GameData/ProceduralParts/Parts/ZOtherMods/USI-LS compatibility.cfg
+++ b/GameData/ProceduralParts/Parts/ZOtherMods/USI-LS compatibility.cfg
@@ -30,6 +30,7 @@ PARTUPGRADE:NEEDS[USILifeSupport]
 		lengthMax = 0.5
 		volumeMin = 0.1
 		volumeMax = 1.0
+		updateDragCubesInEditor:NEEDS[FerramAerospaceResearch] = true
 
 		UPGRADES
 		{


### PR DESCRIPTION
Turns out that FAR uses them in some places.