### PR TITLE
Extract TUTexturePickerGUI as a separate component

### DIFF
--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -106,8 +106,12 @@ namespace ProceduralParts
             {
                 Debug.Log($"{ModTag} TechLimits: {part.name} diameter=({diameterMin:G3}, {diameterMax:G3}) length=({lengthMin:G3}, {lengthMax:G3}) volume=({volumeMin:G3}, {volumeMax:G3})");
                 legacyTextureHandler.ValidateSelectedTexture();
-                texturePickerGUI = new TUTexturePickerGUI(this);
-                Fields[nameof(showTUPickerGUI)].guiActiveEditor = installedTU && !forceLegacyTextures;
+                BaseField bf = Fields[nameof(showTUPickerGUI)];
+                bf.guiActiveEditor = installedTU && !forceLegacyTextures;
+                if (bf.guiActiveEditor)
+                {
+                    bf.uiControlEditor.onFieldChanged = OnShowTUPickerGUIChanged;
+                }
             }
 
             if (shape is ProceduralAbstractShape)
@@ -162,7 +166,21 @@ namespace ProceduralParts
             GameEvents.onVariantApplied.Remove(OnVariantApplied);
             GameEvents.onGameSceneSwitchRequested.Remove(OnEditorExit);
         }
-        public void OnGUI() => texturePickerGUI?.OnGUI();
+
+        private void OnShowTUPickerGUIChanged(BaseField f, object obj)
+        {
+            if (showTUPickerGUI && texturePickerGUI == null)
+            {
+                texturePickerGUI = gameObject.AddComponent<TUTexturePickerGUI>();
+                texturePickerGUI.ShowForPart(this);
+            }
+            else if (!showTUPickerGUI && texturePickerGUI != null)
+            {
+                Destroy(texturePickerGUI);
+                texturePickerGUI = null;
+            }
+        }
+
         private void OnEditorExit(GameEvents.FromToAction<GameScenes, GameScenes> _) => showTUPickerGUI = false;
         private void OnForceLegacyTextureChanged(BaseField f, object obj) { SetTextureFieldVisibility(); UpdateTexture(); }
         public void OnTextureChanged(BaseField f, object obj) => UpdateTexture();

--- a/Source/TUTexturePickerGUI.cs
+++ b/Source/TUTexturePickerGUI.cs
@@ -65,7 +65,7 @@ namespace ProceduralParts
         }
     }
 
-    internal class TUTexturePickerGUI
+    internal class TUTexturePickerGUI : MonoBehaviour
     {
         private const int GUIWidth = 400;
         private const int GUIHeight = 500;
@@ -91,7 +91,7 @@ namespace ProceduralParts
         private static readonly TextureSetContainerMaskComparer MasksComparer = new TextureSetContainerMaskComparer();
         private Vector2 scrollPos = new Vector2();
 
-        public TUTexturePickerGUI(ProceduralPart parent)
+        public void ShowForPart(ProceduralPart parent)
         {
             this.parent = parent;
             SetupTUReflection();
@@ -110,6 +110,7 @@ namespace ProceduralParts
                 Window = GUILayout.Window(GetHashCode(), Window, GUIDisplay, "Textures Unlimited Texture Selector", GUILayout.Width(GUIWidth), GUILayout.Height(GUIHeight));
             }
         }
+
         private void BuildToggles()
         {
             MainToggles.Clear();
@@ -186,7 +187,13 @@ namespace ProceduralParts
                 GUILayout.EndScrollView();
             }
 
-            if (GUILayout.Button("Close")) parent.showTUPickerGUI = false;
+            if (GUILayout.Button("Close"))
+            {
+                Destroy(this);
+                parent.showTUPickerGUI = false;
+                parent.texturePickerGUI = null;
+            }
+
             GUI.DragWindow();
         }
 


### PR DESCRIPTION
This allows getting rid of the PM-level OnGUI and should substantially increase performance on vessels that have many ProcParts.