### PR TITLE
Preserve dimensions when switching shapes

### DIFF
--- a/Source/ProceduralAbstractShape.cs
+++ b/Source/ProceduralAbstractShape.cs
@@ -207,6 +207,16 @@ namespace ProceduralParts
         public abstract void AdjustDimensionBounds();
         public abstract void TranslateAttachmentsAndNodes(BaseField f, object obj);
 
+        /// <summary>
+        /// Copy the bounding dimensions of the previously selected shape onto this shape's editable
+        /// fields, so switching shape in the editor preserves the part's overall size (length and
+        /// outer/inner diameters) instead of snapping to this shape's persisted defaults. Concrete
+        /// shapes map the generic <see cref="Length"/>/<see cref="MaxDiameter"/>/<see cref="InnerMaxDiameter"/>
+        /// onto their own fields; the caller runs AdjustDimensionBounds()/UpdateShape() afterward to
+        /// clamp to this shape's limits. The base implementation keeps the shape's own dimensions.
+        /// </summary>
+        public virtual void CopyDimensions(ProceduralAbstractShape fromShape) { }
+
         public virtual void HandleLengthChange(float length, float oldLength)
         {
             float trans = length - oldLength;

--- a/Source/ProceduralPart.cs
+++ b/Source/ProceduralPart.cs
@@ -451,8 +451,25 @@ namespace ProceduralParts
 
             fromShape.isEnabled = fromShape.enabled = false;
 
+            bool refreshed = false;
             if (shape != fromShape)
             {
+                // Preserve the part's size across the shape switch: copy the previous shape's
+                // bounding length/diameters onto the new shape and refresh its geometry *before*
+                // repositioning attachments below, so they map onto the same dimensions instead of
+                // the new shape's persisted defaults (which would shift the part and its children).
+                // This is the only AdjustDimensionBounds()/UpdateShape() pass when it runs -- the
+                // tail call below is skipped (refreshed) to avoid a second full mesh rebuild and the
+                // duplicate model/collider-changed events that drives.
+                if (HighLogic.LoadedSceneIsEditor)
+                {
+                    shape.isEnabled = shape.enabled = true;
+                    shape.CopyDimensions(fromShape);
+                    shape.AdjustDimensionBounds();
+                    shape.UpdateShape();
+                    refreshed = true;
+                }
+
                 ProceduralAbstractShape.ShapeCoordinates coord = new ProceduralAbstractShape.ShapeCoordinates();
                 // For each surface-attached child, get the cylindrical coordinates, normalize them, and re-attach.
                 foreach (Part child in part.children)
@@ -477,9 +494,12 @@ namespace ProceduralParts
             }
 
             shape.isEnabled = shape.enabled = true;
-            shape.AdjustDimensionBounds();
-            shape.UpdateShape();
-            if (HighLogic.LoadedSceneIsEditor) 
+            if (!refreshed)
+            {
+                shape.AdjustDimensionBounds();
+                shape.UpdateShape();
+            }
+            if (HighLogic.LoadedSceneIsEditor)
             {
                 shape.ChangeVolume(shape.volumeName, shape.Volume);
                 GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);

--- a/Source/ProceduralShapeBezierCone.cs
+++ b/Source/ProceduralShapeBezierCone.cs
@@ -350,6 +350,12 @@ namespace ProceduralParts
             }
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            topDiameter = bottomDiameter = fromShape.MaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             float maxLength = PPart.lengthMax;

--- a/Source/ProceduralShapeCone.cs
+++ b/Source/ProceduralShapeCone.cs
@@ -164,6 +164,12 @@ namespace ProceduralParts
             Profiler.EndSample();
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            topDiameter = bottomDiameter = fromShape.MaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             // V = (PI * length * (topDiameter * topDiameter + topDiameter * bottomDiameter + bottomDiameter * bottomDiameter)) / 12f;

--- a/Source/ProceduralShapeCylinder.cs
+++ b/Source/ProceduralShapeCylinder.cs
@@ -72,6 +72,12 @@ namespace ProceduralParts
             Profiler.EndSample();
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            diameter = fromShape.MaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             // V = 1/4 * pi * L * (d*d)

--- a/Source/ProceduralShapeHollowCone.cs
+++ b/Source/ProceduralShapeHollowCone.cs
@@ -73,6 +73,15 @@ namespace ProceduralParts
             }
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            topOuterDiameter = bottomOuterDiameter = fromShape.MaxDiameter;
+            // Carry the source's bore if it had one; AdjustDimensionBounds() clamps it inside the wall.
+            if (fromShape.InnerMaxDiameter > 0f)
+                topInnerDiameter = bottomInnerDiameter = fromShape.InnerMaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             float bottomMaxOuterDiameter = PPart.diameterMax;
@@ -93,6 +102,10 @@ namespace ProceduralParts
 
             bool bottomAllowedZero = topOuterDiameter > topInnerDiameter;
             bottomMaxInnerDiameter = Mathf.Clamp(bottomMaxInnerDiameter, 0f, bottomOuterDiameter - (bottomAllowedZero ? 0f : PPart.diameterMin));
+            // Enforce the bore staying inside the wall for any setter, not just the slider (see
+            // ProceduralShapeHollowCylinder). Uses the same allowed-zero max as the slider, so a
+            // closed end (inner == outer, when the other end is open) is still permitted.
+            bottomInnerDiameter = Mathf.Min(bottomInnerDiameter, bottomMaxInnerDiameter);
             bottomMinOuterDiameter = Mathf.Clamp(bottomMinOuterDiameter, bottomInnerDiameter + (bottomAllowedZero ? 0f : PPart.diameterMin), bottomMaxOuterDiameter);
 
             // Clamp top diameters
@@ -101,6 +114,7 @@ namespace ProceduralParts
 
             bool topAllowedZero = bottomOuterDiameter > bottomInnerDiameter;
             topMaxInnerDiameter = Mathf.Clamp(topMaxInnerDiameter, 0f, topOuterDiameter - (topAllowedZero ? 0f : PPart.diameterMin));
+            topInnerDiameter = Mathf.Min(topInnerDiameter, topMaxInnerDiameter);
             topMinOuterDiameter = Mathf.Clamp(topMinOuterDiameter, topInnerDiameter + (topAllowedZero ? 0f : PPart.diameterMin), topMaxOuterDiameter);
 
             minLength = Mathf.Clamp(minLength, PPart.lengthMin, PPart.lengthMax - PPart.lengthSmallStep);

--- a/Source/ProceduralShapeHollowCylinder.cs
+++ b/Source/ProceduralShapeHollowCylinder.cs
@@ -59,6 +59,16 @@ namespace ProceduralParts
             }
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            outerDiameter = fromShape.MaxDiameter;
+            // Carry the source's bore if it had one; AdjustDimensionBounds() (run by the caller)
+            // clamps it to stay inside the wall.
+            if (fromShape.InnerMaxDiameter > 0f)
+                innerDiameter = fromShape.InnerMaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             float maxOuterDiameter = PPart.diameterMax;
@@ -72,6 +82,10 @@ namespace ProceduralParts
             maxInnerDiameter = Mathf.Clamp(maxInnerDiameter, 0f, PPart.diameterMax);
 
             maxInnerDiameter = Mathf.Clamp(maxInnerDiameter, 0f, outerDiameter - PPart.diameterMin);
+            // Enforce the bore staying inside the wall for any setter, not just the slider: the
+            // lines below only bound the slider range, so clamp the value too. Otherwise a
+            // programmatic write (shape switch, external code) can leave inner >= outer.
+            innerDiameter = Mathf.Min(innerDiameter, maxInnerDiameter);
             minOuterDiameter = Mathf.Clamp(minOuterDiameter, innerDiameter + PPart.diameterMin, maxOuterDiameter);
 
             minLength = Mathf.Clamp(minLength, PPart.lengthMin, PPart.lengthMax - PPart.lengthSmallStep);

--- a/Source/ProceduralShapeHollowPill.cs
+++ b/Source/ProceduralShapeHollowPill.cs
@@ -81,6 +81,15 @@ namespace ProceduralParts
             }
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            outerDiameter = fromShape.MaxDiameter;
+            // Carry the source's bore if it had one; AdjustDimensionBounds() clamps it inside the wall.
+            if (fromShape.InnerMaxDiameter > 0f)
+                innerDiameter = fromShape.InnerMaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             float maxOuterDiameter = PPart.diameterMax;
@@ -104,11 +113,18 @@ namespace ProceduralParts
             maxOuterDiameter = Mathf.Clamp(maxOuterDiameter, PPart.diameterMin, PPart.diameterMax);
             maxInnerDiameter = Mathf.Clamp(maxInnerDiameter, 0f, PPart.diameterMax);
             maxInnerDiameter = Mathf.Clamp(maxInnerDiameter, 0f, outerDiameter - PPart.diameterMin);
+            // Enforce the bore staying inside the wall for any setter, not just the slider (see
+            // ProceduralShapeHollowCylinder): clamp the value, not only the slider range.
+            innerDiameter = Mathf.Min(innerDiameter, maxInnerDiameter);
 
             minOuterDiameter = Mathf.Clamp(minOuterDiameter, innerDiameter + PPart.diameterMin, maxOuterDiameter);
 
             maxFillet = Mathf.Clamp(maxFillet, 0, length);
             maxFillet = Mathf.Clamp(maxFillet, 0, (outerDiameter - innerDiameter) / 2f);
+            // Clamp the fillet value too, not just the slider: a shape switch (CopyDimensions) can
+            // leave a large persisted fillet against a newly thin wall / short length, which would
+            // drive MinorRadius / MinDiameter negative and build a degenerate torus.
+            fillet = Mathf.Min(fillet, maxFillet);
 
             (Fields[nameof(outerDiameter)].uiControlEditor as UI_FloatEdit).maxValue = maxOuterDiameter;
             (Fields[nameof(outerDiameter)].uiControlEditor as UI_FloatEdit).minValue = minOuterDiameter;

--- a/Source/ProceduralShapeHollowTruss.cs
+++ b/Source/ProceduralShapeHollowTruss.cs
@@ -95,6 +95,14 @@ namespace ProceduralParts
                 MonoUtilities.RefreshPartContextWindow(part);
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            // Map the source diameter onto the truss envelope (top/bottom rings); leave the rod
+            // thickness alone. realLength is derived from these, so it follows automatically.
+            topDiameter = bottomDiameter = fromShape.MaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             float maxLength = PPart.lengthMax;

--- a/Source/ProceduralShapePill.cs
+++ b/Source/ProceduralShapePill.cs
@@ -91,6 +91,12 @@ namespace ProceduralParts
             }
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            diameter = fromShape.MaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             // v = 1/24 pi (6 d^2 l+3 (pi-4) d f^2+(10-3 pi) f^3) for d
@@ -131,6 +137,11 @@ namespace ProceduralParts
 
             minLength = Mathf.Clamp(minLength, PPart.lengthMin, PPart.lengthMax - PPart.lengthSmallStep);
             minDiameter = Mathf.Clamp(minDiameter, PPart.diameterMin, PPart.diameterMax - PPart.diameterSmallStep);
+
+            // Clamp the fillet value too, not just the slider: a shape switch (CopyDimensions) can
+            // leave a large persisted fillet against a newly small diameter/length, building a
+            // degenerate capsule.
+            fillet = Mathf.Min(fillet, maxFillet);
 
             (Fields[nameof(diameter)].uiControlEditor as UI_FloatEdit).maxValue = maxDiameter;
             (Fields[nameof(length)].uiControlEditor as UI_FloatEdit).maxValue = maxLength;

--- a/Source/ProceduralShapePolygon.cs
+++ b/Source/ProceduralShapePolygon.cs
@@ -163,6 +163,12 @@ namespace ProceduralParts
             Profiler.EndSample();
         }
 
+        public override void CopyDimensions(ProceduralAbstractShape fromShape)
+        {
+            length = fromShape.Length;
+            diameter = fromShape.MaxDiameter;
+        }
+
         public override void AdjustDimensionBounds()
         {
             float maxDiameter = PPart.diameterMax;


### PR DESCRIPTION
Switching a part's procedural shape in the editor reset every dimension to the new shape's persisted defaults, which often shifted the part and its attached children and is just generally not what users want for an existing part. Turning a cylinder into a cone or vice versa is probably the most common case where it's very annoying to not have the dimensions carry over, so here we carry the previous shape's bounding length and outer/inner diameter onto the new shape instead.

- Add ProceduralAbstractShape.CopyDimensions(fromShape): no-op by default, overridden per shape to map the generic Length / MaxDiameter / InnerMaxDiameter onto its own fields. Called from ProceduralPart.ChangeShape (editor only) before the attachment reposition so nodes/children map onto the same size. Cones collapse to a straight profile; a truss maps the diameter to its top/bottom envelope; hollow shapes carry the bore.
- ChangeShape does a single AdjustDimensionBounds()/UpdateShape() pass per switch (the tail pass is skipped once the editor block has refreshed), avoiding a redundant mesh rebuild and the duplicate model/collider-changed events it would fire.
- Enforce dimension validity for programmatic writes, not just the sliders: hollow shapes clamp the inner-diameter value below the outer, and the pill shapes clamp the fillet value to its max, in AdjustDimensionBounds -- so a carried-in thin wall can't build a degenerate torus/capsule.